### PR TITLE
fix: cache handler patch not matching require.resolve

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,5 +26,6 @@ test-results
 .sst.config*
 .next/
 .open-next/
+.wrangler
 
 coverage/

--- a/packages/cloudflare/src/cli/build/patches/plugins/open-next.ts
+++ b/packages/cloudflare/src/cli/build/patches/plugins/open-next.ts
@@ -34,14 +34,18 @@ export function patchResolveCache(updater: ContentUpdater, buildOpts: BuildOptio
 
 export const cacheHandlerRule = `
 rule:
-  pattern: var cacheHandlerPath = __require.resolve("./cache.cjs");
+  any:
+    - pattern: var cacheHandlerPath = __require.resolve("./cache.cjs");
+    - pattern: var cacheHandlerPath = require.resolve("./cache.cjs");
 fix: |-
   var cacheHandlerPath = "";
 `;
 
 export const compositeCacheHandlerRule = `
 rule:
-  pattern: var composableCacheHandlerPath = __require.resolve("./composable-cache.cjs");
+  any:
+    - pattern: var composableCacheHandlerPath = __require.resolve("./composable-cache.cjs");
+    - pattern: var composableCacheHandlerPath = require.resolve("./composable-cache.cjs");
 fix: |-
   var composableCacheHandlerPath = "";
 `;


### PR DESCRIPTION
If the the adapters api `fixRequire` patch is applied, `__require` is replaced with `require`, which results in the patch to replace the cache handler paths failing to match. 