### PR TITLE
chore(ci): update changesets github token

### DIFF
--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           # See https://github.com/changesets/action/issues/187
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GH_ACCESS_TOKEN }}
           fetch-depth: 0
       - uses: ./.github/actions/setup
 
@@ -38,5 +38,5 @@ jobs:
         with:
           publish: pnpm exec changeset publish
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
           NODE_ENV: production


### PR DESCRIPTION
updates to use the same workers-frameworks pat that opennextjs-cloudflare is using so that ci checks can always run
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/opennextjs/adapters-api/pull/40" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->