### PR TITLE
Cache: route all caching through the cache override

### DIFF
--- a/.changeset/cache-consolidate-override.md
+++ b/.changeset/cache-consolidate-override.md
@@ -1,0 +1,32 @@
+---
+"@opennextjs/core": major
+"@opennextjs/cloudflare": minor
+---
+
+Route all caching through the `cache` override
+
+The incremental cache and the tag cache no longer run inside the server function. They run in the
+cache handler function, which the server, the middleware and the composable cache reach through the
+`cache` override. Tag revalidation - `hasBeenRevalidated`, `writeTags` and CDN invalidation - moves
+with them, so `get`, `set` and `revalidateTags` now handle tags transparently.
+
+`incrementalCache` and `tagCache` are removed from `default.override` and from the middleware
+override. Configurations that are not created by `defineCloudflareConfig` should move them to the
+top level `cacheHandler` option and set `default.override.cache`:
+
+```diff
+  default: {
+    override: {
+-     incrementalCache: "s3",
+-     tagCache: "dynamodb",
++     cache: "local",
+    },
+  },
++ cacheHandler: {
++   incrementalCache: "s3",
++   tagCache: "dynamodb",
++ },
+```
+
+`defineCloudflareConfig` is unchanged: it now wires the cache to the `OpenNextCache` entrypoint on
+its own.

--- a/examples/app-pages-router/open-next.config.ts
+++ b/examples/app-pages-router/open-next.config.ts
@@ -3,9 +3,8 @@ import type { OpenNextConfig, OverrideOptions } from "@opennextjs/core/types/ope
 const devOverride = {
 	wrapper: "express-dev",
 	converter: "node",
-	incrementalCache: "fs-dev",
+	cache: "local",
 	queue: "direct",
-	tagCache: "fs-dev-nextMode",
 } satisfies OverrideOptions;
 
 export default {
@@ -25,6 +24,14 @@ export default {
 			converter: "dummy",
 		},
 		loader: "fs-dev",
+	},
+	cacheHandler: {
+		override: {
+			wrapper: "dummy",
+			converter: "dummy",
+		},
+		incrementalCache: "fs-dev",
+		tagCache: "fs-dev-nextMode",
 	},
 	// You can override the build command here so that you don't have to rebuild next every time you make a change
 	// buildCommand: "echo 'No build command'",

--- a/examples/app-router/open-next.config.ts
+++ b/examples/app-router/open-next.config.ts
@@ -5,9 +5,8 @@ export default {
 		override: {
 			wrapper: "express-dev",
 			converter: "node",
-			incrementalCache: "fs-dev",
+			cache: "local",
 			queue: "direct",
-			tagCache: "fs-dev-nextMode",
 		},
 	},
 
@@ -21,6 +20,15 @@ export default {
 			converter: "dummy",
 		},
 		loader: "fs-dev",
+	},
+
+	cacheHandler: {
+		override: {
+			wrapper: "dummy",
+			converter: "dummy",
+		},
+		incrementalCache: "fs-dev",
+		tagCache: "fs-dev-nextMode",
 	},
 
 	// You can override the build command here so that you don't have to rebuild next every time you make a change

--- a/examples/experimental/open-next.config.ts
+++ b/examples/experimental/open-next.config.ts
@@ -5,9 +5,8 @@ export default {
 		override: {
 			wrapper: "express-dev",
 			converter: "node",
-			incrementalCache: "fs-dev",
 			queue: "direct",
-			tagCache: "fs-dev-nextMode",
+			cache: "local",
 		},
 	},
 
@@ -17,6 +16,15 @@ export default {
 			converter: "dummy",
 		},
 		loader: "fs-dev",
+	},
+
+	cacheHandler: {
+		override: {
+			wrapper: "dummy",
+			converter: "dummy",
+		},
+		incrementalCache: "fs-dev",
+		tagCache: "fs-dev-nextMode",
 	},
 
 	// You can override the build command here so that you don't have to rebuild next every time you make a change

--- a/examples/pages-router/open-next.config.ts
+++ b/examples/pages-router/open-next.config.ts
@@ -3,9 +3,8 @@ export default {
 		override: {
 			wrapper: "express-dev",
 			converter: "node",
-			incrementalCache: "fs-dev",
 			queue: "direct",
-			tagCache: "dummy",
+			cache: "local",
 		},
 	},
 
@@ -15,6 +14,15 @@ export default {
 			converter: "dummy",
 		},
 		loader: "fs-dev",
+	},
+
+	cacheHandler: {
+		override: {
+			wrapper: "dummy",
+			converter: "dummy",
+		},
+		incrementalCache: "fs-dev",
+		tagCache: "dummy",
 	},
 
 	// You can override the build command here so that you don't have to rebuild next every time you make a change

--- a/packages/cloudflare/src/api/config.ts
+++ b/packages/cloudflare/src/api/config.ts
@@ -13,6 +13,7 @@ import type {
 } from "@opennextjs/core/types/overrides.js";
 
 import assetResolver from "./overrides/asset-resolver/index.js";
+import serviceCache from "./overrides/cache/service-cache.js";
 
 export type Override<T extends BaseOverride> = "dummy" | T | LazyLoadedOverride<T>;
 
@@ -65,12 +66,17 @@ export function defineCloudflareConfig(config: CloudflareOverrides = {}): OpenNe
 				wrapper: "cloudflare-node",
 				converter: "edge",
 				proxyExternalRequest: "fetch",
-				incrementalCache: resolveIncrementalCache(incrementalCache),
-				tagCache: resolveTagCache(tagCache),
+				cache: () => serviceCache,
 				queue: resolveQueue(queue),
 				cdnInvalidation: resolveCdnInvalidation(cachePurge),
 			},
 			routePreloadingBehavior,
+		},
+		// The cache runs in the same worker, behind the `OpenNextCache` named entrypoint.
+		cacheHandler: {
+			incrementalCache: resolveIncrementalCache(incrementalCache),
+			tagCache: resolveTagCache(tagCache),
+			cdnInvalidation: resolveCdnInvalidation(cachePurge),
 		},
 		// node:crypto is used to compute cache keys
 		edgeExternals: ["node:crypto"],
@@ -83,8 +89,7 @@ export function defineCloudflareConfig(config: CloudflareOverrides = {}): OpenNe
 				wrapper: "cloudflare-edge",
 				converter: "edge",
 				proxyExternalRequest: "fetch",
-				incrementalCache: resolveIncrementalCache(incrementalCache),
-				tagCache: resolveTagCache(tagCache),
+				cache: () => serviceCache,
 				queue: resolveQueue(queue),
 			},
 			assetResolver: () => assetResolver,

--- a/packages/cloudflare/src/api/overrides/cache/service-cache.spec.ts
+++ b/packages/cloudflare/src/api/overrides/cache/service-cache.spec.ts
@@ -28,13 +28,20 @@ describe("serviceCache", () => {
 	});
 
 	describe("get", () => {
-		it("requests the key and the cache type", async () => {
-			await serviceCache.get("key/with/slashes", "fetch");
+		it("requests the key, the cache type and the additional tags", async () => {
+			await serviceCache.get("key/with/slashes", "fetch", ["tag1", "tag2"]);
 
 			const { url, method } = lastRequest();
 			expect(method).toBe("GET");
 			expect(url.pathname).toBe(`/cache/${encodeURIComponent("key/with/slashes")}`);
 			expect(url.searchParams.get("type")).toBe("fetch");
+			expect(url.searchParams.get("tags")).toBe("tag1,tag2");
+		});
+
+		it("omits the tags when there is none", async () => {
+			await serviceCache.get("key", "cache", []);
+
+			expect(lastRequest().url.searchParams.has("tags")).toBe(false);
 		});
 
 		it("returns null on a cache miss", async () => {

--- a/packages/cloudflare/src/api/overrides/cache/service-cache.ts
+++ b/packages/cloudflare/src/api/overrides/cache/service-cache.ts
@@ -35,12 +35,16 @@ function getCacheService(): Service {
 	return service;
 }
 
-function getCacheUrl(key: string, cacheType?: CacheEntryType) {
+function getCacheUrl(key: string, cacheType?: CacheEntryType, additionalTags?: string[]) {
 	const url = new URL(`/cache/${encodeURIComponent(key)}`, CACHE_ORIGIN);
 
 	if (cacheType) {
 		url.searchParams.set("type", cacheType);
 	}
+	if (additionalTags && additionalTags.length > 0) {
+		url.searchParams.set("tags", additionalTags.join(","));
+	}
+
 	return url.href;
 }
 
@@ -53,8 +57,8 @@ function getCacheUrl(key: string, cacheType?: CacheEntryType) {
 const serviceCache = {
 	name: NAME,
 
-	get: async (key, cacheType) => {
-		const response = await getCacheService().fetch(getCacheUrl(key, cacheType));
+	get: async (key, cacheType, additionalTags) => {
+		const response = await getCacheService().fetch(getCacheUrl(key, cacheType, additionalTags));
 
 		const body = await response.text();
 		const headers: Record<string, string> = {};

--- a/packages/cloudflare/src/api/overrides/internal.ts
+++ b/packages/cloudflare/src/api/overrides/internal.ts
@@ -34,7 +34,10 @@ export function computeCacheKey(key: string, options: KeyOptions) {
 
 export function isPurgeCacheEnabled(): boolean {
 	// The `?` is required at `openNextConfig?` or the Open Next build fails because of a type error
-	const cdnInvalidation = globalThis.openNextConfig?.default?.override?.cdnInvalidation;
+	// The cache handler function only has `cacheHandler` populated, the other functions only have `default`.
+	const cdnInvalidation =
+		globalThis.openNextConfig?.cacheHandler?.cdnInvalidation ??
+		globalThis.openNextConfig?.default?.override?.cdnInvalidation;
 
 	return cdnInvalidation !== undefined && cdnInvalidation !== "dummy";
 }

--- a/packages/cloudflare/src/cli/build/utils/ensure-cf-config.ts
+++ b/packages/cloudflare/src/cli/build/utils/ensure-cf-config.ts
@@ -17,12 +17,12 @@ export function ensureCloudflareConfig(config: OpenNextConfig) {
 		dftUseCloudflareWrapper: config.default?.override?.wrapper === "cloudflare-node",
 		dftUseEdgeConverter: config.default?.override?.converter === "edge",
 		dftUseFetchProxy: config.default?.override?.proxyExternalRequest === "fetch",
-		dftMaybeUseCache:
-			config.default?.override?.incrementalCache === "dummy" ||
-			typeof config.default?.override?.incrementalCache === "function",
-		dftMaybeUseTagCache:
-			config.default?.override?.tagCache === "dummy" ||
-			typeof config.default?.override?.incrementalCache === "function",
+		dftUseCacheClient: typeof config.default?.override?.cache === "function",
+		chMaybeUseIncrementalCache:
+			config.cacheHandler?.incrementalCache === "dummy" ||
+			typeof config.cacheHandler?.incrementalCache === "function",
+		chMaybeUseTagCache:
+			config.cacheHandler?.tagCache === "dummy" || typeof config.cacheHandler?.tagCache === "function",
 		dftMaybeUseQueue:
 			config.default?.override?.queue === "dummy" ||
 			config.default?.override?.queue === "direct" ||
@@ -32,6 +32,7 @@ export function ensureCloudflareConfig(config: OpenNextConfig) {
 		mwUseCloudflareWrapper: mwConfig?.override?.wrapper === "cloudflare-edge",
 		mwUseEdgeConverter: mwConfig?.override?.converter === "edge",
 		mwUseFetchProxy: mwConfig?.override?.proxyExternalRequest === "fetch",
+		mwUseCacheClient: typeof mwConfig?.override?.cache === "function",
 		hasCryptoExternal: config.edgeExternals?.includes("node:crypto"),
 	};
 
@@ -48,10 +49,13 @@ export function ensureCloudflareConfig(config: OpenNextConfig) {
               wrapper: "cloudflare-node",
               converter: "edge",
               proxyExternalRequest: "fetch",
-              incrementalCache: "dummy" | function,
-              tagCache: "dummy" | function,
+              cache: function,
               queue: "dummy" | "direct" | function,
             },
+          },
+          cacheHandler: {
+            incrementalCache: "dummy" | function,
+            tagCache: "dummy" | function,
           },
           edgeExternals: ["node:crypto"],
           middleware: {
@@ -60,8 +64,7 @@ export function ensureCloudflareConfig(config: OpenNextConfig) {
               wrapper: "cloudflare-edge",
               converter: "edge",
               proxyExternalRequest: "fetch",
-              incrementalCache: "dummy" | function,
-              tagCache: "dummy" | function,
+              cache: function,
               queue: "dummy" | "direct" | function,
             },
           },

--- a/packages/cloudflare/src/cli/commands/populate-cache.spec.ts
+++ b/packages/cloudflare/src/cli/commands/populate-cache.spec.ts
@@ -113,10 +113,8 @@ describe("populateCache", () => {
 						outputDir: "/test/output",
 					} as BuildOptions,
 					{
-						default: {
-							override: {
-								incrementalCache: "cf-r2-incremental-cache",
-							},
+						cacheHandler: {
+							incrementalCache: "cf-r2-incremental-cache",
 						},
 					} as any, // oxlint-disable-line @typescript-eslint/no-explicit-any
 					{
@@ -149,10 +147,8 @@ describe("populateCache", () => {
 						outputDir: "/test/output",
 					} as BuildOptions,
 					{
-						default: {
-							override: {
-								incrementalCache: "cf-r2-incremental-cache",
-							},
+						cacheHandler: {
+							incrementalCache: "cf-r2-incremental-cache",
 						},
 					} as any, // oxlint-disable-line @typescript-eslint/no-explicit-any
 					{

--- a/packages/cloudflare/src/cli/commands/populate-cache.ts
+++ b/packages/cloudflare/src/cli/commands/populate-cache.ts
@@ -90,7 +90,7 @@ export async function populateCache(
 	populateCacheOptions: PopulateCacheOptions,
 	envVars: WorkerEnvVar
 ) {
-	const { incrementalCache, tagCache } = config.default.override ?? {};
+	const { incrementalCache, tagCache } = config.cacheHandler ?? {};
 
 	if (!fs.existsSync(buildOpts.outputDir)) {
 		logger.error("Unable to populate cache: Open Next build not found");

--- a/packages/core/src/adapters/cache-adapter.ts
+++ b/packages/core/src/adapters/cache-adapter.ts
@@ -13,7 +13,7 @@ import type {
 
 import { createGenericHandler } from "../core/createGenericHandler.js";
 import { resolveCdnInvalidation, resolveIncrementalCache, resolveTagCache } from "../core/resolve.js";
-import { writeTags } from "../utils/cache.js";
+import { getTagsFromValue, writeTags } from "../utils/cache.js";
 import { runWithOpenNextRequestContext } from "../utils/promise.js";
 import { toReadableStream } from "../utils/stream.js";
 
@@ -30,13 +30,9 @@ async function initializeCaches() {
 	if (initialized) return;
 	const config = globalThis.openNextConfig;
 
-	globalThis.incrementalCache = await resolveIncrementalCache(
-		config.cacheHandler?.incrementalCache ?? config.default?.override?.incrementalCache
-	);
+	globalThis.incrementalCache = await resolveIncrementalCache(config.cacheHandler?.incrementalCache);
 
-	globalThis.tagCache = await resolveTagCache(
-		config.cacheHandler?.tagCache ?? config.default?.override?.tagCache
-	);
+	globalThis.tagCache = await resolveTagCache(config.cacheHandler?.tagCache);
 
 	globalThis.cdnInvalidationHandler = await resolveCdnInvalidation(
 		config.cacheHandler?.cdnInvalidation ?? config.default?.override?.cdnInvalidation
@@ -89,9 +85,11 @@ async function defaultHandler(
 		const rawType = typeof query?.type === "string" ? query.type : undefined;
 		const cacheType: CacheEntryType = rawType === "fetch" || rawType === "composable" ? rawType : "cache";
 
+		const additionalTags = query?.tags ? (query.tags as string).split(",") : [];
+
 		switch (method) {
 			case "GET":
-				return await handleGet(key, cacheType);
+				return await handleGet(key, cacheType, additionalTags);
 			case "PUT":
 				return await handleSet(key, cacheType, body);
 			case "DELETE":
@@ -109,8 +107,12 @@ async function defaultHandler(
 // Route handlers   //
 //////////////////////
 
-async function handleGet(key: string, cacheType: CacheEntryType): Promise<InternalResult> {
-	debug("get", { key, cacheType });
+async function handleGet(
+	key: string,
+	cacheType: CacheEntryType,
+	additionalTags: string[]
+): Promise<InternalResult> {
+	debug("get", { key, cacheType, additionalTags });
 
 	try {
 		const result = await globalThis.incrementalCache.get(key, cacheType);
@@ -128,11 +130,61 @@ async function handleGet(key: string, cacheType: CacheEntryType): Promise<Intern
 			};
 		}
 
+		// `getTagsFromValue` also strips the internal `x-next-cache-tags` header from the entry, so
+		// the tags are derived for every hit - including the ones bypassing the tag cache - or that
+		// header would be handed back to Next.js and echoed to the client.
+		let tags: string[] = [...additionalTags];
+
+		if (cacheType === "cache") {
+			tags = [...tags, ...getTagsFromValue(result.value as CacheValue<"cache">)];
+		} else if (cacheType === "fetch") {
+			const fetchValue = result.value as CachedFetchValue;
+			tags = [...tags, ...(fetchValue.tags ?? []), ...(fetchValue.data?.tags ?? [])];
+		} else if (cacheType === "composable") {
+			const composableValue = result.value as StoredComposableCacheEntry;
+			tags = [...tags, ...(composableValue.tags ?? [])];
+		}
+
+		if (!result.shouldBypassTagCache) {
+			if (tags.length > 0) {
+				const revalidated = await checkTagRevalidation(key, tags, result);
+				if (revalidated) {
+					return {
+						type: "core",
+						statusCode: 404,
+						body: toReadableStream(""),
+						isBase64Encoded: false,
+						headers: {
+							"x-opennext-cache-found": "false",
+							"x-opennext-cache-tag-status": "revalidated",
+							"Cache-Control": "no-store",
+						},
+					};
+				}
+			}
+		}
+
 		return buildCacheGetResponse(result);
 	} catch (e) {
 		error("Failed to get cache entry", e);
 		return buildErrorResponse("Failed to get cache entry", 500);
 	}
+}
+
+async function checkTagRevalidation(
+	key: string,
+	tags: string[],
+	cacheEntry: WithLastModified<CacheValue<CacheEntryType>>
+): Promise<boolean> {
+	if (globalThis.openNextConfig?.dangerous?.disableTagCache || tags.length === 0) {
+		return false;
+	}
+	const lastModified = cacheEntry.lastModified ?? Date.now();
+	if (globalThis.tagCache.mode === "nextMode") {
+		return globalThis.tagCache.hasBeenRevalidated(tags, lastModified);
+	}
+	const _lastModified = await globalThis.tagCache.getLastModified(key, lastModified);
+	return _lastModified === -1;
 }
 
 async function handleSet(key: string, cacheType: CacheEntryType, body?: Buffer): Promise<InternalResult> {
@@ -156,6 +208,45 @@ async function handleSet(key: string, cacheType: CacheEntryType, body?: Buffer):
 
 	try {
 		await globalThis.incrementalCache.set(key, payload.value as CacheValue<CacheEntryType>, cacheType);
+
+		// `writeTags` deduplicates through the OpenNext request context and gives up when there is
+		// none. The cache handler runs as its own function, so nothing established a context for us.
+		await runWithOpenNextRequestContext({ isISRRevalidation: false }, async () => {
+			// Write tags for non-composable and non-nextMode tag caches
+			const tagCache = globalThis.tagCache;
+			// TODO: fix this horrible typing
+			if (tagCache.mode !== "nextMode" && !globalThis.openNextConfig?.dangerous?.disableTagCache) {
+				let derivedTags: string[] = [];
+
+				if (cacheType === "cache") {
+					const tags = getTagsFromValue(payload.value as CacheValue<"cache">);
+					derivedTags = tags;
+				} else if (cacheType === "fetch") {
+					const fetchValue = payload.value as CacheValue<"fetch">;
+					const data = fetchValue.data as Record<string, unknown> | undefined;
+					derivedTags = (fetchValue.tags as string[]) ?? (data?.tags as string[]) ?? [];
+				} else if (cacheType === "composable") {
+					const composableValue = payload.value as CacheValue<"composable">;
+					derivedTags = composableValue.tags ?? [];
+				}
+
+				if (derivedTags.length > 0) {
+					const storedTags = await tagCache.getByPath(key);
+					const tagsToWrite = derivedTags.filter((tag) => !storedTags.includes(tag));
+					if (tagsToWrite.length > 0) {
+						await writeTags(
+							tagsToWrite.map((tag) => ({
+								path: key,
+								tag,
+								revalidatedAt: 1,
+							})),
+							tagCache
+						);
+					}
+				}
+			}
+		});
+
 		return buildJsonResponse({ ok: true }, 200);
 	} catch (e) {
 		error("Failed to set cache entry", e);

--- a/packages/core/src/adapters/cache.ts
+++ b/packages/core/src/adapters/cache.ts
@@ -1,11 +1,8 @@
 import type { CacheHandlerValue, IncrementalCacheContext, IncrementalCacheValue } from "@/types/cache";
-import { getTagsFromValue, hasBeenRevalidated, writeTags } from "@/utils/cache";
 
 import { isBinaryContentType } from "../utils/binary";
 
 import { debug, error, warn } from "./logger";
-
-export const SOFT_TAG_PREFIX = "_N_T_/";
 
 function isFetchCache(options?: { kindHint?: "app" | "pages" | "fetch"; kind?: "FETCH" }): boolean {
 	if (typeof options === "object") {
@@ -29,47 +26,21 @@ export default class Cache {
 			return null;
 		}
 
-		const softTags = typeof options === "object" ? options.softTags : [];
-		const tags = typeof options === "object" ? options.tags : [];
-		return isFetchCache(options) ? this.getFetchCache(key, softTags, tags) : this.getIncrementalCache(key);
+		return isFetchCache(options)
+			? this.getFetchCache(key, [...(options?.tags ?? []), ...(options?.softTags ?? [])])
+			: this.getIncrementalCache(key);
 	}
 
-	async getFetchCache(key: string, softTags?: string[], tags?: string[]) {
-		debug("get fetch cache", { key, softTags, tags });
+	async getFetchCache(key: string, additionalTags: string[] = []): Promise<CacheHandlerValue | null> {
+		debug("get fetch cache", { key });
 		try {
-			const cachedEntry = await globalThis.incrementalCache.get(key, "fetch");
+			const result = await globalThis.cache.get(key, "fetch", additionalTags);
 
-			if (cachedEntry?.value === undefined) return null;
-
-			const _tags = [...(tags ?? []), ...(softTags ?? [])];
-			const _lastModified = cachedEntry.lastModified ?? Date.now();
-			const _hasBeenRevalidated = cachedEntry.shouldBypassTagCache
-				? false
-				: await hasBeenRevalidated<"fetch">(key, _tags, cachedEntry);
-
-			if (_hasBeenRevalidated) return null;
-
-			// For cases where we don't have tags, we need to ensure that the soft tags are not being revalidated
-			// We only need to check for the path as it should already contain all the tags
-			if ((tags ?? []).length === 0) {
-				// Then we need to find the path for the given key
-				const path = softTags?.find(
-					(tag) => tag.startsWith(SOFT_TAG_PREFIX) && !tag.endsWith("layout") && !tag.endsWith("page")
-				);
-				if (path) {
-					const hasPathBeenUpdated = cachedEntry.shouldBypassTagCache
-						? false
-						: await hasBeenRevalidated<"fetch">(path.replace(SOFT_TAG_PREFIX, ""), [], cachedEntry);
-					if (hasPathBeenUpdated) {
-						// In case the path has been revalidated, we don't want to use the fetch cache
-						return null;
-					}
-				}
-			}
+			if (!result?.value) return null;
 
 			return {
-				lastModified: _lastModified,
-				value: cachedEntry.value,
+				lastModified: result.lastModified ?? Date.now(),
+				value: result.value,
 			} as CacheHandlerValue;
 		} catch (e) {
 			// We can usually ignore errors here as they are usually due to cache not being found
@@ -80,7 +51,7 @@ export default class Cache {
 
 	async getIncrementalCache(key: string): Promise<CacheHandlerValue | null> {
 		try {
-			const cachedEntry = await globalThis.incrementalCache.get(key, "cache");
+			const cachedEntry = await globalThis.cache.get(key, "cache");
 
 			if (!cachedEntry?.value) {
 				return null;
@@ -89,12 +60,7 @@ export default class Cache {
 			const cacheData = cachedEntry.value;
 
 			const meta = cacheData.meta;
-			const tags = getTagsFromValue(cacheData);
 			const _lastModified = cachedEntry.lastModified ?? Date.now();
-			const _hasBeenRevalidated = cachedEntry.shouldBypassTagCache
-				? false
-				: await hasBeenRevalidated(key, tags, cachedEntry);
-			if (_hasBeenRevalidated) return null;
 
 			const store = globalThis.__openNextAls.getStore();
 			if (store) {
@@ -174,14 +140,14 @@ export default class Cache {
 		const detachedPromise = globalThis.__openNextAls.getStore()?.pendingPromiseRunner.withResolvers<void>();
 		try {
 			if (data === null || data === undefined) {
-				await globalThis.incrementalCache.delete(key);
+				await globalThis.cache.delete(key);
 			} else {
 				const revalidate = this.extractRevalidateForSet(ctx);
 				switch (data.kind) {
 					case "ROUTE":
 					case "APP_ROUTE": {
 						const { body, status, headers } = data;
-						await globalThis.incrementalCache.set(
+						await globalThis.cache.set(
 							key,
 							{
 								type: "route",
@@ -201,7 +167,7 @@ export default class Cache {
 						const { html, pageData, status, headers } = data;
 						const isAppPath = typeof pageData === "string";
 						if (isAppPath) {
-							await globalThis.incrementalCache.set(
+							await globalThis.cache.set(
 								key,
 								{
 									type: "app",
@@ -216,7 +182,7 @@ export default class Cache {
 								"cache"
 							);
 						} else {
-							await globalThis.incrementalCache.set(
+							await globalThis.cache.set(
 								key,
 								{
 									type: "page",
@@ -237,7 +203,7 @@ export default class Cache {
 								segmentToWrite[segmentPath] = segmentContent.toString("utf8");
 							}
 						}
-						await globalThis.incrementalCache.set(
+						await globalThis.cache.set(
 							key,
 							{
 								type: "app",
@@ -256,10 +222,10 @@ export default class Cache {
 						break;
 					}
 					case "FETCH":
-						await globalThis.incrementalCache.set(key, data, "fetch");
+						await globalThis.cache.set(key, data, "fetch");
 						break;
 					case "REDIRECT":
-						await globalThis.incrementalCache.set(
+						await globalThis.cache.set(
 							key,
 							{
 								type: "redirect",
@@ -275,7 +241,6 @@ export default class Cache {
 				}
 			}
 
-			await this.updateTagsOnSet(key, data, ctx);
 			debug("Finished setting cache");
 		} catch (e) {
 			error("Failed to set cache", e);
@@ -296,132 +261,9 @@ export default class Cache {
 		}
 
 		try {
-			if (globalThis.tagCache.mode === "nextMode") {
-				const paths = (await globalThis.tagCache.getPathsByTags?.(_tags)) ?? [];
-
-				await writeTags(_tags);
-				if (paths.length > 0) {
-					// TODO: we should introduce a new method in cdnInvalidationHandler to invalidate paths by tags for cdn that supports it
-					// It also means that we'll need to provide the tags used in every request to the wrapper or converter.
-					await globalThis.cdnInvalidationHandler.invalidatePaths(
-						paths.map((path) => ({
-							initialPath: path,
-							rawPath: path,
-							resolvedRoutes: [
-								{
-									route: path,
-									// TODO: ideally here we should check if it's an app router page or route
-									type: "app",
-									isFallback: false,
-								},
-							],
-						}))
-					);
-				}
-				return;
-			}
-
-			for (const tag of _tags) {
-				debug("revalidateTag", tag);
-				// Find all keys with the given tag
-				const paths = await globalThis.tagCache.getByTag(tag);
-				debug("Items", paths);
-				const toInsert = paths.map((path) => ({
-					path,
-					tag,
-				}));
-
-				// If the tag is a soft tag, we should also revalidate the hard tags
-				if (tag.startsWith(SOFT_TAG_PREFIX)) {
-					for (const path of paths) {
-						// We need to find all hard tags for a given path
-						const _tags = await globalThis.tagCache.getByPath(path);
-						const hardTags = _tags.filter((t) => !t.startsWith(SOFT_TAG_PREFIX));
-						// For every hard tag, we need to find all paths and revalidate them
-						for (const hardTag of hardTags) {
-							const _paths = await globalThis.tagCache.getByTag(hardTag);
-							debug({ hardTag, _paths });
-							toInsert.push(
-								..._paths.map((path) => ({
-									path,
-									tag: hardTag,
-								}))
-							);
-						}
-					}
-				}
-
-				// Update all keys with the given tag with revalidatedAt set to now
-				await writeTags(toInsert);
-
-				// We can now invalidate all paths in the CDN
-				// This only applies to `revalidateTag`, not to `res.revalidate()`
-				const uniquePaths = Array.from(
-					new Set(
-						toInsert
-							// We need to filter fetch cache key as they are not in the CDN
-							.filter((t) => t.tag.startsWith(SOFT_TAG_PREFIX))
-							.map((t) => `/${t.path}`)
-					)
-				);
-				if (uniquePaths.length > 0) {
-					await globalThis.cdnInvalidationHandler.invalidatePaths(
-						uniquePaths.map((path) => ({
-							initialPath: path,
-							rawPath: path,
-							resolvedRoutes: [
-								{
-									route: path,
-									// TODO: ideally here we should check if it's an app router page or route
-									type: "app",
-									isFallback: false,
-								},
-							],
-						}))
-					);
-				}
-			}
+			await globalThis.cache.revalidateTags(_tags);
 		} catch (e) {
 			error("Failed to revalidate tag", e);
-		}
-	}
-
-	// TODO: We should delete/update tags in this method
-	// This will require an update to the tag cache interface
-	private async updateTagsOnSet(key: string, data?: IncrementalCacheValue, ctx?: IncrementalCacheContext) {
-		if (
-			globalThis.openNextConfig.dangerous?.disableTagCache ||
-			globalThis.tagCache.mode === "nextMode" ||
-			// Here it means it's a delete
-			!data
-		) {
-			return;
-		}
-		// Write derivedTags to the tag cache
-		// If we use an in house version of getDerivedTags in build we should use it here instead of next's one
-		const derivedTags: string[] =
-			data?.kind === "FETCH"
-				? //@ts-expect-error - On older versions of next, ctx was a number, but for these cases we use data?.data?.tags
-					(ctx?.tags ?? data?.data?.tags ?? []) // before version 14 next.js used data?.data?.tags so we keep it for backward compatibility
-				: data?.kind === "PAGE"
-					? (data.headers?.["x-next-cache-tags"]?.split(",") ?? [])
-					: [];
-		debug("derivedTags", derivedTags);
-
-		// Get all tags stored in dynamodb for the given key
-		// If any of the derived tags are not stored in dynamodb for the given key, write them
-		const storedTags = await globalThis.tagCache.getByPath(key);
-		const tagsToWrite = derivedTags.filter((tag) => !storedTags.includes(tag));
-		if (tagsToWrite.length > 0) {
-			await writeTags(
-				tagsToWrite.map((tag) => ({
-					path: key,
-					tag: tag,
-					// In case the tags are not there we just need to create them
-					// but we don't want them to return from `getLastModified` as they are not stale
-					revalidatedAt: 1,
-				}))
-			);
 		}
 	}
 

--- a/packages/core/src/adapters/composable-cache.ts
+++ b/packages/core/src/adapters/composable-cache.ts
@@ -1,6 +1,5 @@
 import type { ComposableCacheEntry, ComposableCacheHandler } from "@/types/cache";
 import type { CacheValue } from "@/types/overrides";
-import { writeTags } from "@/utils/cache";
 import { fromReadableStream, toReadableStream } from "@/utils/stream";
 
 import { debug } from "./logger";
@@ -21,25 +20,12 @@ export default {
 					}));
 				}
 			}
-			const result = await globalThis.incrementalCache.get(cacheKey, "composable");
+			const result = await globalThis.cache.get(cacheKey, "composable");
 			if (!result?.value?.value) {
 				return undefined;
 			}
 
 			debug("composable cache result", result);
-
-			// We need to check if the tags associated with this entry has been revalidated
-			if (globalThis.tagCache.mode === "nextMode" && result.value.tags.length > 0) {
-				const hasBeenRevalidated = result.shouldBypassTagCache
-					? false
-					: await globalThis.tagCache.hasBeenRevalidated(result.value.tags, result.lastModified);
-				if (hasBeenRevalidated) return undefined;
-			} else if (globalThis.tagCache.mode === "original" || globalThis.tagCache.mode === undefined) {
-				const hasBeenRevalidated = result.shouldBypassTagCache
-					? false
-					: (await globalThis.tagCache.getLastModified(cacheKey, result.lastModified)) === -1;
-				if (hasBeenRevalidated) return undefined;
-			}
 
 			return {
 				...result.value,
@@ -61,7 +47,7 @@ export default {
 		const entry = await promiseEntry.finally(() => {
 			pendingWritePromiseMap.delete(cacheKey);
 		});
-		await globalThis.incrementalCache.set(
+		await globalThis.cache.set(
 			cacheKey,
 			{
 				...entry,
@@ -69,13 +55,6 @@ export default {
 			},
 			"composable"
 		);
-		if (globalThis.tagCache.mode === "original") {
-			const storedTags = await globalThis.tagCache.getByPath(cacheKey);
-			const tagsToWrite = entry.tags.filter((tag) => !storedTags.includes(tag));
-			if (tagsToWrite.length > 0) {
-				await writeTags(tagsToWrite.map((tag) => ({ tag, path: cacheKey })));
-			}
-		}
 	},
 
 	async refreshTags() {
@@ -89,12 +68,8 @@ export default {
 	 * - From Next.js 16, the method takes `tags: string[]`
 	 */
 	async getExpiration(...tags: string[] | string[][]) {
-		if (globalThis.tagCache.mode === "nextMode") {
-			// Use `.flat()` to accommodate both signatures
-			return globalThis.tagCache.getLastRevalidated(tags.flat());
-		}
-		// We always return 0 here, original tag cache are handled directly in the get part
-		// TODO: We need to test this more, i'm not entirely sure that this is working as expected
+		// Tag revalidation is handled transparently in the cache layer's get(),
+		// so we always return 0 here to let get() determine freshness.
 		return 0;
 	},
 
@@ -102,29 +77,10 @@ export default {
 	 * This method is only used before Next.js 16
 	 */
 	async expireTags(...tags: string[]) {
-		if (globalThis.tagCache.mode === "nextMode") {
-			return writeTags(tags);
+		const flatTags = tags.flat();
+		if (flatTags.length > 0) {
+			await globalThis.cache.revalidateTags(flatTags);
 		}
-		const tagCache = globalThis.tagCache;
-		const revalidatedAt = Date.now();
-		// For the original mode, we have more work to do here.
-		// We need to find all paths linked to to these tags
-		const pathsToUpdate = await Promise.all(
-			tags.map(async (tag) => {
-				const paths = await tagCache.getByTag(tag);
-				return paths.map((path) => ({
-					path,
-					tag,
-					revalidatedAt,
-				}));
-			})
-		);
-		// We need to deduplicate paths, we use a set for that
-		const setToWrite = new Set<{ path: string; tag: string }>();
-		for (const entry of pathsToUpdate.flat()) {
-			setToWrite.add(entry);
-		}
-		await writeTags(Array.from(setToWrite));
 	},
 
 	// This one is necessary for older versions of next

--- a/packages/core/src/adapters/middleware.ts
+++ b/packages/core/src/adapters/middleware.ts
@@ -12,11 +12,9 @@ import { createGenericHandler } from "../core/createGenericHandler";
 import {
 	resolveAssetResolver,
 	resolveCache,
-	resolveIncrementalCache,
 	resolveOriginResolver,
 	resolveProxyRequest,
 	resolveQueue,
-	resolveTagCache,
 } from "../core/resolve";
 import { constructNextUrl } from "../core/routing/util";
 import routingHandler, {
@@ -41,11 +39,7 @@ const defaultHandler = async (
 
 	const assetResolver = await resolveAssetResolver(middlewareConfig?.assetResolver);
 
-	globalThis.tagCache = await resolveTagCache(middlewareConfig?.override?.tagCache);
-
 	globalThis.queue = await resolveQueue(middlewareConfig?.override?.queue);
-
-	globalThis.incrementalCache = await resolveIncrementalCache(middlewareConfig?.override?.incrementalCache);
 
 	globalThis.cache = await resolveCache(middlewareConfig?.override?.cache);
 

--- a/packages/core/src/build/edge/createEdgeBundle.ts
+++ b/packages/core/src/build/edge/createEdgeBundle.ts
@@ -77,8 +77,7 @@ export async function buildEdgeBundle({
 					overrides: {
 						wrapper: override("wrapper"),
 						converter: override("converter"),
-						tagCache: override("tagCache"),
-						incrementalCache: override("incrementalCache"),
+						cache: override("cache"),
 						queue: override("queue"),
 						originResolver: override("originResolver"),
 						proxyExternalRequest: override("proxyExternalRequest"),
@@ -86,9 +85,7 @@ export async function buildEdgeBundle({
 					defaultOverrides: {
 						wrapper: defaultOverrides?.wrapper ?? "@opennextjs/core/overrides/wrappers/dummy.js",
 						converter: defaultOverrides?.converter ?? defaultConverter,
-						tagCache: defaultOverrides?.tagCache ?? "@opennextjs/core/overrides/tagCache/dummy.js",
-						incrementalCache:
-							defaultOverrides?.incrementalCache ?? "@opennextjs/core/overrides/incrementalCache/dummy.js",
+						cache: defaultOverrides?.cache ?? "@opennextjs/core/overrides/cache/dummy.js",
 						queue: defaultOverrides?.queue ?? "@opennextjs/core/overrides/queue/direct.js",
 						originResolver:
 							defaultOverrides?.originResolver ?? "@opennextjs/core/overrides/originResolver/pattern-env.js",

--- a/packages/core/src/build/generateOutput.ts
+++ b/packages/core/src/build/generateOutput.ts
@@ -143,18 +143,20 @@ async function extractOverrideFn(override?: DefaultOverrideOptions) {
 	return { wrapper, converter };
 }
 
+//TODO: fix this, this is stupid
 async function extractCommonOverride(override?: OverrideOptions) {
 	if (!override) {
 		return {
 			queue: "sqs",
-			incrementalCache: "s3",
-			tagCache: "dynamodb",
+			incrementalCache: "s3" as const,
+			tagCache: "dynamodb" as const,
 		};
 	}
 	const queue = await extractOverrideName("sqs", override.queue);
-	const incrementalCache = await extractOverrideName("s3", override.incrementalCache);
-	const tagCache = await extractOverrideName("dynamodb", override.tagCache);
-	return { queue, incrementalCache, tagCache };
+	// incrementalCache and tagCache are no longer in OverrideOptions — they use defaults.
+	// When using a composite cache (default), composite.ts wraps s3 + dynamodb internally.
+	// Custom implementations should be provided via the cacheHandler config or a custom cache override.
+	return { queue, incrementalCache: "s3" as const, tagCache: "dynamodb" as const };
 }
 
 function prefixPattern(basePath: string) {

--- a/packages/core/src/build/middleware/buildNodeMiddleware.ts
+++ b/packages/core/src/build/middleware/buildNodeMiddleware.ts
@@ -65,8 +65,7 @@ export async function buildExternalNodeMiddleware(
 					overrides: {
 						wrapper: override("wrapper"),
 						converter: override("converter"),
-						tagCache: override("tagCache"),
-						incrementalCache: override("incrementalCache"),
+						cache: override("cache"),
 						queue: override("queue"),
 						originResolver: override("originResolver"),
 						proxyExternalRequest: override("proxyExternalRequest"),
@@ -74,9 +73,7 @@ export async function buildExternalNodeMiddleware(
 					defaultOverrides: {
 						wrapper: defaultOverrides?.wrapper ?? "@opennextjs/core/overrides/wrappers/node.js",
 						converter: defaultOverrides?.converter ?? "@opennextjs/core/overrides/converters/node.js",
-						tagCache: defaultOverrides?.tagCache ?? "@opennextjs/core/overrides/tagCache/dummy.js",
-						incrementalCache:
-							defaultOverrides?.incrementalCache ?? "@opennextjs/core/overrides/incrementalCache/dummy.js",
+						cache: defaultOverrides?.cache ?? "@opennextjs/core/overrides/cache/dummy.js",
 						queue: defaultOverrides?.queue ?? "@opennextjs/core/overrides/queue/direct.js",
 						originResolver:
 							defaultOverrides?.originResolver ?? "@opennextjs/core/overrides/originResolver/pattern-env.js",

--- a/packages/core/src/core/createMainHandler.ts
+++ b/packages/core/src/core/createMainHandler.ts
@@ -9,10 +9,8 @@ import {
 	resolveCache,
 	resolveCdnInvalidation,
 	resolveConverter,
-	resolveIncrementalCache,
 	resolveProxyRequest,
 	resolveQueue,
-	resolveTagCache,
 	resolveWrapper,
 } from "./resolve";
 
@@ -31,10 +29,6 @@ export async function createMainHandler() {
 
 	// Default queue
 	globalThis.queue = await resolveQueue(thisFunction.override?.queue);
-
-	globalThis.incrementalCache = await resolveIncrementalCache(thisFunction.override?.incrementalCache);
-
-	globalThis.tagCache = await resolveTagCache(thisFunction.override?.tagCache);
 
 	if (config.middleware?.external !== true) {
 		globalThis.assetResolver = await resolveAssetResolver(

--- a/packages/core/src/core/resolve.ts
+++ b/packages/core/src/core/resolve.ts
@@ -44,7 +44,9 @@ export async function resolveWrapper<
  * @returns
  * @__PURE__
  */
-export async function resolveTagCache(tagCache: OverrideOptions["tagCache"]): Promise<TagCache> {
+export async function resolveTagCache(
+	tagCache: RemoveUndefined<OpenNextConfig["cacheHandler"]>["tagCache"]
+): Promise<TagCache> {
 	if (typeof tagCache === "function") {
 		return tagCache();
 	}
@@ -72,7 +74,9 @@ export async function resolveQueue(queue: OverrideOptions["queue"]) {
  * @returns
  * @__PURE__
  */
-export async function resolveIncrementalCache(incrementalCache: OverrideOptions["incrementalCache"]) {
+export async function resolveIncrementalCache(
+	incrementalCache: RemoveUndefined<OpenNextConfig["cacheHandler"]>["incrementalCache"]
+) {
 	if (typeof incrementalCache === "function") {
 		return incrementalCache();
 	}

--- a/packages/core/src/core/routing/cacheInterceptor.ts
+++ b/packages/core/src/core/routing/cacheInterceptor.ts
@@ -4,7 +4,6 @@ import { NextConfig, PrerenderManifest } from "@/config/index";
 import type { InternalEvent, InternalResult, MiddlewareEvent, PartialResult } from "@/types/open-next";
 import type { CacheValue } from "@/types/overrides";
 import { isBinaryContentType } from "@/utils/binary";
-import { getTagsFromValue, hasBeenRevalidated } from "@/utils/cache";
 import { emptyReadableStream, toReadableStream } from "@/utils/stream";
 
 import { debug, error } from "../../adapters/logger";
@@ -340,23 +339,11 @@ export async function cacheInterceptor(
 			} else if (localizedPath === "") {
 				pathToUse = "/index";
 			}
-			const cachedData = await globalThis.incrementalCache.get(pathToUse);
+			const cachedData = await globalThis.cache.get(pathToUse);
 			debug("cached data in interceptor", cachedData);
 
 			if (!cachedData?.value) {
 				return event;
-			}
-			// We need to check the tag cache now
-			if (cachedData.value?.type === "app" || cachedData.value?.type === "route") {
-				const tags = getTagsFromValue(cachedData.value);
-
-				const _hasBeenRevalidated = cachedData.shouldBypassTagCache
-					? false
-					: await hasBeenRevalidated(localizedPath, tags, cachedData);
-
-				if (_hasBeenRevalidated) {
-					return event;
-				}
 			}
 			const host = event.headers.host;
 			switch (cachedData?.value?.type) {

--- a/packages/core/src/overrides/cache/fetch.ts
+++ b/packages/core/src/overrides/cache/fetch.ts
@@ -5,9 +5,10 @@ const CACHE_URL = process.env.OPEN_NEXT_CACHE_URL ?? "";
 
 const fetchCache: Cache = {
 	name: "fetch-cache",
-	get: async (key, cacheType) => {
+	get: async (key, cacheType, additionalTags) => {
 		const query: Record<string, string> = {};
 		if (cacheType) query.type = cacheType;
+		if (additionalTags && additionalTags.length > 0) query.tags = additionalTags.join(",");
 		const queryString = Object.keys(query).length > 0 ? `?${new URLSearchParams(query).toString()}` : "";
 		const url = `${CACHE_URL}/cache/${encodeURIComponent(key)}${queryString}`;
 		const response = await fetch(url, { method: "GET" });

--- a/packages/core/src/overrides/cache/local.ts
+++ b/packages/core/src/overrides/cache/local.ts
@@ -19,17 +19,20 @@ async function getHandler() {
 
 const localCache: Cache = {
 	name: "local-cache",
-	get: async (key, cacheType) => {
+	get: async (key, cacheType, additionalTags) => {
 		const h = (await getHandler())!;
 		const encodedKey = encodeURIComponent(key);
 		const url = `https://on/cache/${encodedKey}`;
+		const query: Record<string, string> = {};
+		if (cacheType) query.type = cacheType;
+		if (additionalTags && additionalTags.length > 0) query.tags = additionalTags.join(",");
 		const event: InternalEvent = {
 			type: "core",
 			method: "GET",
 			rawPath: `/cache/${encodedKey}`,
 			url,
 			headers: {},
-			query: cacheType ? { type: cacheType } : {},
+			query,
 			cookies: {},
 			remoteAddress: "127.0.0.1",
 		};

--- a/packages/core/src/plugins/resolve.ts
+++ b/packages/core/src/plugins/resolve.ts
@@ -8,12 +8,14 @@ import type { Plugin } from "esbuild";
 import type {
 	DefaultOverrideOptions,
 	IncludedImageLoader,
+	IncludedIncrementalCache,
 	IncludedOriginResolver,
+	IncludedTagCache,
 	IncludedWarmer,
 	LazyLoadedOverride,
 	OverrideOptions,
 } from "@/types/open-next";
-import type { ImageLoader, OriginResolver, Warmer } from "@/types/overrides";
+import type { ImageLoader, IncrementalCache, OriginResolver, TagCache, Warmer } from "@/types/overrides";
 
 import logger from "../logger.js";
 import { getCrossPlatformPathRegex } from "../utils/regex.js";
@@ -24,9 +26,9 @@ export interface IPluginSettings {
 		wrapper?: DefaultOverrideOptions<any, any>["wrapper"];
 		// oxlint-disable-next-line @typescript-eslint/no-explicit-any - generic overrides for flexibility
 		converter?: DefaultOverrideOptions<any, any>["converter"];
-		tagCache?: OverrideOptions["tagCache"];
+		tagCache?: IncludedTagCache | LazyLoadedOverride<TagCache>;
 		queue?: OverrideOptions["queue"];
-		incrementalCache?: OverrideOptions["incrementalCache"];
+		incrementalCache?: IncludedIncrementalCache | LazyLoadedOverride<IncrementalCache>;
 		imageLoader?: LazyLoadedOverride<ImageLoader> | IncludedImageLoader;
 		originResolver?: LazyLoadedOverride<OriginResolver> | IncludedOriginResolver;
 		warmer?: LazyLoadedOverride<Warmer> | IncludedWarmer;

--- a/packages/core/src/types/global.ts
+++ b/packages/core/src/types/global.ts
@@ -75,15 +75,15 @@ declare global {
 	// Needed in the cache adapter
 	/**
 	 * The cache adapter for incremental static regeneration.
-	 * Only available in main functions and in the external middleware when `enableCacheInterception` is `true`.
-	 * Defined in `createMainHandler` and in `adapters/middleware.ts`.
+	 * Only set in the cache handler function (cache-adapter.ts) from `cacheHandler` config.
+	 * Not available in main functions or middleware anymore — use `globalThis.cache` instead.
 	 */
 	var incrementalCache: IncrementalCache;
 
 	/**
 	 * The cache adapter for the tag cache.
-	 * Only available in main functions and in the external middleware when `enableCacheInterception` is `true`.
-	 * Defined in `createMainHandler` and in `adapters/middleware.ts`.
+	 * Only set in the cache handler function (cache-adapter.ts) from `cacheHandler` config.
+	 * Not available in main functions or middleware anymore — use `globalThis.cache` instead.
 	 */
 	var tagCache: TagCache;
 

--- a/packages/core/src/types/open-next.ts
+++ b/packages/core/src/types/open-next.ts
@@ -255,18 +255,6 @@ export interface DefaultOverrideOptions<
 
 export interface OverrideOptions extends DefaultOverrideOptions {
 	/**
-	 * Add possibility to override the default s3 cache. Used for fetch cache and html/rsc/json cache.
-	 * @default "s3"
-	 */
-	incrementalCache?: IncludedIncrementalCache | LazyLoadedOverride<IncrementalCache>;
-
-	/**
-	 * Add possibility to override the default tag cache. Used for revalidateTags and revalidatePath.
-	 * @default "dynamodb"
-	 */
-	tagCache?: IncludedTagCache | LazyLoadedOverride<TagCache>;
-
-	/**
 	 * Add possibility to override the default queue. Used for isr.
 	 * @default "sqs"
 	 */

--- a/packages/core/src/types/overrides.ts
+++ b/packages/core/src/types/overrides.ts
@@ -256,7 +256,8 @@ export type ProxyExternalRequest = BaseOverride & {
 export type Cache = BaseOverride & {
 	get<CacheType extends CacheEntryType = "cache">(
 		key: string,
-		cacheType?: CacheType
+		cacheType?: CacheType,
+		additionalTags?: string[]
 	): Promise<WithLastModified<CacheValue<CacheType>> | null>;
 	set<CacheType extends CacheEntryType = "cache">(
 		key: string,

--- a/packages/core/src/utils/cache.ts
+++ b/packages/core/src/utils/cache.ts
@@ -2,6 +2,7 @@ import type {
 	CacheEntryType,
 	CacheValue,
 	OriginalTagCacheWriteInput,
+	TagCache,
 	WithLastModified,
 } from "@/types/overrides";
 
@@ -10,7 +11,8 @@ import { debug } from "../adapters/logger";
 export async function hasBeenRevalidated<T extends CacheEntryType = "cache">(
 	key: string,
 	tags: string[],
-	cacheEntry: WithLastModified<CacheValue<T>>
+	cacheEntry: WithLastModified<CacheValue<T>>,
+	tagCache: TagCache = globalThis.tagCache
 ): Promise<boolean> {
 	if (globalThis.openNextConfig.dangerous?.disableTagCache) {
 		return false;
@@ -24,11 +26,11 @@ export async function hasBeenRevalidated<T extends CacheEntryType = "cache">(
 		return false;
 	}
 	const lastModified = cacheEntry.lastModified ?? Date.now();
-	if (globalThis.tagCache.mode === "nextMode") {
-		return tags.length === 0 ? false : await globalThis.tagCache.hasBeenRevalidated(tags, lastModified);
+	if (tagCache.mode === "nextMode") {
+		return tags.length === 0 ? false : await tagCache.hasBeenRevalidated(tags, lastModified);
 	}
 	// TODO: refactor this, we should introduce a new method in the tagCache interface so that both implementations use hasBeenRevalidated
-	const _lastModified = await globalThis.tagCache.getLastModified(key, lastModified);
+	const _lastModified = await tagCache.getLastModified(key, lastModified);
 	return _lastModified === -1;
 }
 
@@ -56,7 +58,10 @@ function getTagKey(tag: string | OriginalTagCacheWriteInput): string {
 	});
 }
 
-export async function writeTags(tags: (string | OriginalTagCacheWriteInput)[]): Promise<void> {
+export async function writeTags(
+	tags: (string | OriginalTagCacheWriteInput)[],
+	tagCache: TagCache = globalThis.tagCache
+): Promise<void> {
 	const store = globalThis.__openNextAls.getStore();
 	debug("Writing tags", tags, store);
 	if (!store || globalThis.openNextConfig.dangerous?.disableTagCache) {
@@ -75,8 +80,7 @@ export async function writeTags(tags: (string | OriginalTagCacheWriteInput)[]): 
 	if (tagsToWrite.length === 0) {
 		return;
 	}
-
 	// Here we know that we have the correct type
 	// oxlint-disable-next-line @typescript-eslint/no-explicit-any - writeTags accepts a union type that typescript cannot infer correctly
-	await globalThis.tagCache.writeTags(tagsToWrite as any);
+	await tagCache.writeTags(tagsToWrite as any);
 }

--- a/packages/tests-unit/tests/adapters/cache-adapter.test.ts
+++ b/packages/tests-unit/tests/adapters/cache-adapter.test.ts
@@ -1,0 +1,680 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+
+import { handler } from "@opennextjs/core/adapters/cache-adapter";
+import type { InternalEvent, InternalResult, OpenNextConfig } from "@opennextjs/core/types/open-next";
+import { fromReadableStream } from "@opennextjs/core/utils/stream";
+import { type Mock, vi, describe, expect, it, beforeEach } from "vitest";
+
+const mockResolveIncrementalCache = vi.hoisted(() => vi.fn());
+const mockResolveTagCache = vi.hoisted(() => vi.fn());
+const mockResolveCdnInvalidation = vi.hoisted(() => vi.fn());
+
+const mockIncrementalCache = vi.hoisted(() => ({
+	name: "mock",
+	get: vi.fn(),
+	set: vi.fn(),
+	delete: vi.fn(),
+}));
+
+const mockTagCache = vi.hoisted(() => ({
+	name: "mock",
+	mode: "original",
+	getByTag: vi.fn(),
+	getByPath: vi.fn(),
+	getLastModified: vi.fn(),
+	writeTags: vi.fn(),
+	hasBeenRevalidated: vi.fn(),
+	getPathsByTags: undefined as Mock | undefined,
+}));
+
+const mockCdnInvalidationHandler = vi.hoisted(() => ({
+	name: "mock",
+	invalidatePaths: vi.fn(),
+}));
+
+vi.mock("@opennextjs/core/core/resolve", () => ({
+	resolveIncrementalCache: mockResolveIncrementalCache,
+	resolveTagCache: mockResolveTagCache,
+	resolveCdnInvalidation: mockResolveCdnInvalidation,
+}));
+
+vi.mock("@opennextjs/core/core/createGenericHandler", () => ({
+	createGenericHandler: vi.fn(
+		async ({
+			handler: h,
+		}: {
+			handler: (event: InternalEvent, options?: unknown) => Promise<InternalResult>;
+		}) => {
+			//@ts-ignore
+			globalThis.openNextConfig = {
+				dangerous: {},
+			} as Partial<OpenNextConfig>;
+			return async (event: InternalEvent, options?: unknown) => h(event, options);
+		}
+	),
+}));
+
+function createEvent(overrides: Partial<InternalEvent> = {}): InternalEvent {
+	return {
+		type: "core",
+		method: "GET",
+		rawPath: "/cache/test-key",
+		url: "https://on/cache/test-key",
+		headers: {},
+		query: {},
+		cookies: {},
+		remoteAddress: "127.0.0.1",
+		...overrides,
+	};
+}
+
+async function runHandler(event: InternalEvent): Promise<InternalResult> {
+	return globalThis.__openNextAls.run(
+		{
+			requestId: "test-request",
+			pendingPromiseRunner: {
+				withResolvers: () => ({
+					resolve: vi.fn(),
+					promise: Promise.resolve(),
+				}),
+			},
+			isISRRevalidation: false,
+			writtenTags: new Set<string>(),
+		},
+		() => handler(event)
+	);
+}
+
+describe("cache-adapter", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		globalThis.__openNextAls = new AsyncLocalStorage();
+		// @ts-ignore
+		globalThis.openNextConfig = { dangerous: {} } as Partial<OpenNextConfig>;
+		mockResolveIncrementalCache.mockResolvedValue(mockIncrementalCache);
+		mockResolveTagCache.mockResolvedValue(mockTagCache);
+		mockResolveCdnInvalidation.mockResolvedValue(mockCdnInvalidationHandler);
+		mockTagCache.mode = "original";
+		mockTagCache.getPathsByTags = undefined;
+	});
+
+	describe("routing", () => {
+		it("should return 404 for non-cache paths", async () => {
+			const event = createEvent({ rawPath: "/other/path" });
+			const result = await runHandler(event);
+
+			expect(result.statusCode).toBe(404);
+			const body = await fromReadableStream(result.body);
+			expect(body).toContain("Not Found");
+		});
+
+		it("should return 400 for missing cache key", async () => {
+			const event = createEvent({ rawPath: "/cache/" });
+			const result = await runHandler(event);
+
+			expect(result.statusCode).toBe(400);
+			const body = await fromReadableStream(result.body);
+			expect(body).toContain("Missing cache key");
+		});
+
+		it("should return 405 for unknown method", async () => {
+			const event = createEvent({ method: "PATCH" });
+			const result = await runHandler(event);
+
+			expect(result.statusCode).toBe(405);
+			const body = await fromReadableStream(result.body);
+			expect(body).toContain("Method Not Allowed");
+		});
+	});
+
+	describe("GET /cache/:key", () => {
+		it("should return 404 when cache entry is not found", async () => {
+			mockIncrementalCache.get.mockResolvedValue(null);
+
+			const result = await runHandler(createEvent());
+
+			expect(result.statusCode).toBe(404);
+			expect(result.headers["x-opennext-cache-found"]).toBe("false");
+		});
+
+		it("should return 404 when cache entry value is missing", async () => {
+			mockIncrementalCache.get.mockResolvedValue({});
+
+			const result = await runHandler(createEvent());
+
+			expect(result.statusCode).toBe(404);
+			expect(result.headers["x-opennext-cache-found"]).toBe("false");
+		});
+
+		it("should return 200 with route cache data", async () => {
+			mockIncrementalCache.get.mockResolvedValue({
+				value: { type: "route", body: "route-body" },
+				lastModified: 1000,
+			});
+
+			const result = await runHandler(createEvent());
+
+			expect(result.statusCode).toBe(200);
+			expect(result.headers["x-opennext-cache-found"]).toBe("true");
+			expect(result.headers["x-opennext-cache-type"]).toBe("cache");
+			expect(result.headers["x-opennext-cache-sub-type"]).toBe("route");
+			expect(result.headers["x-opennext-cache-last-modified"]).toBe("1000");
+			const body = await fromReadableStream(result.body);
+			expect(body).toBe("route-body");
+		});
+
+		it("should return 200 with page cache data", async () => {
+			mockIncrementalCache.get.mockResolvedValue({
+				value: { type: "page", html: "<html>", json: { data: 1 } },
+				lastModified: 1000,
+			});
+
+			const result = await runHandler(createEvent());
+
+			expect(result.statusCode).toBe(200);
+			expect(result.headers["x-opennext-cache-type"]).toBe("cache");
+			expect(result.headers["x-opennext-cache-sub-type"]).toBe("page");
+			const body = await fromReadableStream(result.body);
+			const parsed = JSON.parse(body);
+			expect(parsed).toEqual({ html: "<html>", json: { data: 1 } });
+		});
+
+		it("should return 200 with app cache data", async () => {
+			mockIncrementalCache.get.mockResolvedValue({
+				value: {
+					type: "app",
+					html: "<html>",
+					rsc: "rsc-data",
+					segmentData: { seg1: "data1" },
+				},
+				lastModified: 1000,
+			});
+
+			const result = await runHandler(createEvent());
+
+			expect(result.statusCode).toBe(200);
+			expect(result.headers["x-opennext-cache-type"]).toBe("cache");
+			expect(result.headers["x-opennext-cache-sub-type"]).toBe("app");
+			const body = await fromReadableStream(result.body);
+			const parsed = JSON.parse(body);
+			expect(parsed.html).toBe("<html>");
+			expect(parsed.rsc).toBe("rsc-data");
+			expect(parsed.segmentData).toEqual({ seg1: "data1" });
+		});
+
+		it("should return 200 with redirect cache data", async () => {
+			mockIncrementalCache.get.mockResolvedValue({
+				value: { type: "redirect", props: { destination: "/new" } },
+				lastModified: 1000,
+			});
+
+			const result = await runHandler(createEvent());
+
+			expect(result.statusCode).toBe(200);
+			expect(result.headers["x-opennext-cache-type"]).toBe("cache");
+			expect(result.headers["x-opennext-cache-sub-type"]).toBe("redirect");
+		});
+
+		it("should return 200 with fetch cache data", async () => {
+			mockIncrementalCache.get.mockResolvedValue({
+				value: {
+					kind: "FETCH",
+					data: {
+						headers: { "content-type": "text/plain" },
+						body: "fetch-body",
+						url: "https://example.com",
+						status: 200,
+					},
+				},
+				lastModified: 1000,
+			});
+
+			const result = await runHandler(createEvent());
+
+			expect(result.statusCode).toBe(200);
+			expect(result.headers["x-opennext-cache-type"]).toBe("fetch");
+			expect(result.headers["x-opennext-cache-fetch-kind"]).toBe("FETCH");
+			expect(result.headers["x-opennext-cache-fetch-data-url"]).toBe("https://example.com");
+			const body = await fromReadableStream(result.body);
+			expect(body).toBe("fetch-body");
+		});
+
+		it("should use ?type=fetch when query param is provided", async () => {
+			mockIncrementalCache.get.mockResolvedValue(null);
+			const event = createEvent({ query: { type: "fetch" } });
+
+			await runHandler(event);
+
+			expect(mockIncrementalCache.get).toHaveBeenCalledWith("test-key", "fetch");
+		});
+
+		it("should use ?type=cache by default", async () => {
+			mockIncrementalCache.get.mockResolvedValue(null);
+
+			await runHandler(createEvent());
+
+			expect(mockIncrementalCache.get).toHaveBeenCalledWith("test-key", "cache");
+		});
+
+		it("should return 500 when incremental cache throws", async () => {
+			mockIncrementalCache.get.mockRejectedValue(new Error("cache error"));
+
+			const result = await runHandler(createEvent());
+
+			expect(result.statusCode).toBe(500);
+		});
+	});
+
+	describe("tag revalidation in GET", () => {
+		it("should return cached value when there are no tags", async () => {
+			mockTagCache.mode = "original";
+			mockIncrementalCache.get.mockResolvedValue({
+				value: { type: "route", body: "data" },
+				lastModified: 1000,
+			});
+
+			const result = await runHandler(createEvent());
+
+			expect(result.statusCode).toBe(200);
+			expect(mockTagCache.getLastModified).not.toHaveBeenCalled();
+		});
+
+		it("should check tag revalidation in nextMode", async () => {
+			mockTagCache.mode = "nextMode";
+			mockTagCache.hasBeenRevalidated.mockResolvedValue(false);
+			mockIncrementalCache.get.mockResolvedValue({
+				value: {
+					type: "route",
+					body: "data",
+					meta: { headers: { "x-next-cache-tags": "tag1" } },
+				},
+				lastModified: 1000,
+			});
+
+			const result = await runHandler(createEvent());
+
+			expect(mockTagCache.hasBeenRevalidated).toHaveBeenCalledWith(["tag1"], 1000);
+			expect(result.statusCode).toBe(200);
+		});
+
+		it("should return 404 when tags have been revalidated in nextMode", async () => {
+			mockTagCache.mode = "nextMode";
+			mockTagCache.hasBeenRevalidated.mockResolvedValue(true);
+			mockIncrementalCache.get.mockResolvedValue({
+				value: {
+					type: "route",
+					body: "data",
+					meta: { headers: { "x-next-cache-tags": "tag1" } },
+				},
+				lastModified: 1000,
+			});
+
+			const result = await runHandler(createEvent());
+
+			expect(result.statusCode).toBe(404);
+			expect(result.headers["x-opennext-cache-tag-status"]).toBe("revalidated");
+		});
+
+		it("should check last modified in original mode", async () => {
+			mockTagCache.mode = "original";
+			mockTagCache.getLastModified.mockResolvedValue(1000);
+			mockIncrementalCache.get.mockResolvedValue({
+				value: {
+					type: "route",
+					body: "data",
+					meta: { headers: { "x-next-cache-tags": "tag1" } },
+				},
+				lastModified: 1000,
+			});
+
+			const result = await runHandler(createEvent());
+
+			expect(mockTagCache.getLastModified).toHaveBeenCalledWith("test-key", 1000);
+			expect(result.statusCode).toBe(200);
+		});
+
+		it("should return 404 when tags have been revalidated in original mode", async () => {
+			mockTagCache.mode = "original";
+			mockTagCache.getLastModified.mockResolvedValue(-1);
+			mockIncrementalCache.get.mockResolvedValue({
+				value: {
+					type: "route",
+					body: "data",
+					meta: { headers: { "x-next-cache-tags": "tag1" } },
+				},
+				lastModified: 1000,
+			});
+
+			const result = await runHandler(createEvent());
+
+			expect(result.statusCode).toBe(404);
+			expect(result.headers["x-opennext-cache-tag-status"]).toBe("revalidated");
+		});
+
+		it("should skip tag revalidation when shouldBypassTagCache is true", async () => {
+			mockIncrementalCache.get.mockResolvedValue({
+				value: { type: "route", body: "data" },
+				lastModified: 1000,
+				shouldBypassTagCache: true,
+			});
+
+			const result = await runHandler(createEvent());
+
+			expect(result.statusCode).toBe(200);
+			expect(mockTagCache.getLastModified).not.toHaveBeenCalled();
+			expect(mockTagCache.hasBeenRevalidated).not.toHaveBeenCalled();
+		});
+
+		it("should skip tag revalidation when disableTagCache is true", async () => {
+			// @ts-ignore
+			globalThis.openNextConfig = {
+				dangerous: { disableTagCache: true },
+			} as Partial<OpenNextConfig>;
+			mockIncrementalCache.get.mockResolvedValue({
+				value: { type: "route", body: "data" },
+				lastModified: 1000,
+			});
+
+			const result = await runHandler(createEvent());
+
+			expect(result.statusCode).toBe(200);
+			expect(mockTagCache.getLastModified).not.toHaveBeenCalled();
+			expect(mockTagCache.hasBeenRevalidated).not.toHaveBeenCalled();
+		});
+	});
+
+	describe("PUT /cache/:key", () => {
+		it("should return 400 when body is missing", async () => {
+			const result = await runHandler(createEvent({ method: "PUT" }));
+
+			expect(result.statusCode).toBe(400);
+		});
+
+		it("should return 400 when body is empty", async () => {
+			const event = createEvent({ method: "PUT", body: Buffer.from("") });
+			const result = await runHandler(event);
+
+			expect(result.statusCode).toBe(400);
+		});
+
+		it("should return 400 when value is missing in body", async () => {
+			const event = createEvent({ method: "PUT", body: Buffer.from(JSON.stringify({})) });
+			const result = await runHandler(event);
+
+			expect(result.statusCode).toBe(400);
+		});
+
+		it("should return 400 when body is invalid JSON", async () => {
+			const event = createEvent({ method: "PUT", body: Buffer.from("invalid json") });
+			const result = await runHandler(event);
+
+			expect(result.statusCode).toBe(400);
+		});
+
+		it("should set cache entry and return 200", async () => {
+			const value = { type: "route", body: "content" };
+			const event = createEvent({
+				method: "PUT",
+				body: Buffer.from(JSON.stringify({ value })),
+			});
+
+			const result = await runHandler(event);
+
+			expect(result.statusCode).toBe(200);
+			expect(mockIncrementalCache.set).toHaveBeenCalledWith("test-key", value, "cache");
+			const body = await fromReadableStream(result.body);
+			expect(JSON.parse(body)).toEqual({ ok: true });
+		});
+
+		it("should write derived tags for non-nextMode tag caches", async () => {
+			mockTagCache.getByPath.mockResolvedValue([]);
+			mockTagCache.mode = "original";
+
+			const value = {
+				type: "route",
+				body: "content",
+				meta: { headers: { "x-next-cache-tags": "tag1,tag2" } },
+			};
+			const event = createEvent({
+				method: "PUT",
+				body: Buffer.from(JSON.stringify({ value })),
+			});
+
+			await runHandler(event);
+
+			expect(mockTagCache.writeTags).toHaveBeenCalled();
+		});
+
+		it("should write derived tags without an ambient request context", async () => {
+			// The cache handler runs as its own function: nothing establishes an OpenNext request
+			// context for it, and `writeTags` gives up when there is none.
+			mockTagCache.getByPath.mockResolvedValue([]);
+			mockTagCache.mode = "original";
+
+			const value = {
+				type: "route",
+				body: "content",
+				meta: { headers: { "x-next-cache-tags": "tag1,tag2" } },
+			};
+			const event = createEvent({
+				method: "PUT",
+				body: Buffer.from(JSON.stringify({ value })),
+			});
+
+			await handler(event);
+
+			expect(mockTagCache.writeTags).toHaveBeenCalled();
+		});
+
+		it("should skip tag writing in nextMode", async () => {
+			mockTagCache.mode = "nextMode";
+			const event = createEvent({
+				method: "PUT",
+				body: Buffer.from(JSON.stringify({ value: { type: "route", body: "content" } })),
+			});
+
+			await runHandler(event);
+
+			expect(mockTagCache.writeTags).not.toHaveBeenCalled();
+		});
+
+		it("should skip tag writing when disableTagCache is true", async () => {
+			// @ts-ignore
+			globalThis.openNextConfig = {
+				dangerous: { disableTagCache: true },
+			} as Partial<OpenNextConfig>;
+			const event = createEvent({
+				method: "PUT",
+				body: Buffer.from(JSON.stringify({ value: { type: "route", body: "content" } })),
+			});
+
+			await runHandler(event);
+
+			expect(mockTagCache.writeTags).not.toHaveBeenCalled();
+		});
+
+		it("should skip writing tags that are already stored", async () => {
+			mockTagCache.getByPath.mockResolvedValue(["tag1", "tag2"]);
+
+			const value = {
+				type: "route",
+				body: "content",
+				meta: { headers: { "x-next-cache-tags": "tag1,tag2" } },
+			};
+			const event = createEvent({
+				method: "PUT",
+				body: Buffer.from(JSON.stringify({ value })),
+			});
+
+			await runHandler(event);
+
+			expect(mockTagCache.writeTags).not.toHaveBeenCalled();
+		});
+
+		it("should return 500 when set fails", async () => {
+			mockIncrementalCache.set.mockRejectedValue(new Error("set error"));
+			const event = createEvent({
+				method: "PUT",
+				body: Buffer.from(JSON.stringify({ value: { type: "route", body: "content" } })),
+			});
+
+			const result = await runHandler(event);
+
+			expect(result.statusCode).toBe(500);
+		});
+	});
+
+	describe("DELETE /cache/:key", () => {
+		it("should delete cache entry and return 200", async () => {
+			const result = await runHandler(createEvent({ method: "DELETE" }));
+
+			expect(result.statusCode).toBe(200);
+			expect(mockIncrementalCache.delete).toHaveBeenCalledWith("test-key");
+			const body = await fromReadableStream(result.body);
+			expect(JSON.parse(body)).toEqual({ ok: true });
+		});
+
+		it("should return 500 when delete fails", async () => {
+			mockIncrementalCache.delete.mockRejectedValue(new Error("delete error"));
+
+			const result = await runHandler(createEvent({ method: "DELETE" }));
+
+			expect(result.statusCode).toBe(500);
+		});
+	});
+
+	describe("POST /cache/revalidate-tags", () => {
+		it("should return 400 when body is missing", async () => {
+			const event = createEvent({ rawPath: "/cache/revalidate-tags", method: "POST" });
+			const result = await runHandler(event);
+
+			expect(result.statusCode).toBe(400);
+		});
+
+		it("should return 400 when body is empty", async () => {
+			const event = createEvent({
+				rawPath: "/cache/revalidate-tags",
+				method: "POST",
+				body: Buffer.from(""),
+			});
+			const result = await runHandler(event);
+
+			expect(result.statusCode).toBe(400);
+		});
+
+		it("should return 400 when tags array is missing", async () => {
+			const event = createEvent({
+				rawPath: "/cache/revalidate-tags",
+				method: "POST",
+				body: Buffer.from(JSON.stringify({})),
+			});
+			const result = await runHandler(event);
+
+			expect(result.statusCode).toBe(400);
+		});
+
+		it("should return 400 when tags are empty array", async () => {
+			const event = createEvent({
+				rawPath: "/cache/revalidate-tags",
+				method: "POST",
+				body: Buffer.from(JSON.stringify({ tags: [] })),
+			});
+			const result = await runHandler(event);
+
+			expect(result.statusCode).toBe(400);
+		});
+
+		it("should return 400 when body is invalid JSON", async () => {
+			const event = createEvent({
+				rawPath: "/cache/revalidate-tags",
+				method: "POST",
+				body: Buffer.from("not json"),
+			});
+			const result = await runHandler(event);
+
+			expect(result.statusCode).toBe(400);
+		});
+
+		it("should revalidate tags in nextMode without getPathsByTags", async () => {
+			mockTagCache.mode = "nextMode";
+			mockTagCache.getPathsByTags = undefined;
+			const event = createEvent({
+				rawPath: "/cache/revalidate-tags",
+				method: "POST",
+				body: Buffer.from(JSON.stringify({ tags: ["tag1"] })),
+			});
+
+			const result = await runHandler(event);
+
+			expect(result.statusCode).toBe(200);
+			expect(mockTagCache.writeTags).toHaveBeenCalled();
+			const body = await fromReadableStream(result.body);
+			const parsed = JSON.parse(body);
+			expect(parsed.revalidated).toEqual(["tag1"]);
+		});
+
+		it("should revalidate tags in nextMode with getPathsByTags and invalidate CDN", async () => {
+			mockTagCache.mode = "nextMode";
+			mockTagCache.getPathsByTags = vi.fn().mockResolvedValue(["/path1"]);
+			const event = createEvent({
+				rawPath: "/cache/revalidate-tags",
+				method: "POST",
+				body: Buffer.from(JSON.stringify({ tags: ["tag1"] })),
+			});
+
+			const result = await runHandler(event);
+
+			expect(result.statusCode).toBe(200);
+			expect(mockTagCache.writeTags).toHaveBeenCalled();
+			expect(mockCdnInvalidationHandler.invalidatePaths).toHaveBeenCalledWith([
+				expect.objectContaining({ initialPath: "/path1", rawPath: "/path1" }),
+			]);
+		});
+
+		it("should revalidate tags in original mode", async () => {
+			mockTagCache.mode = "original";
+			mockTagCache.getByTag.mockResolvedValue(["/path1"]);
+			mockTagCache.getByPath.mockResolvedValue([]);
+			const event = createEvent({
+				rawPath: "/cache/revalidate-tags",
+				method: "POST",
+				body: Buffer.from(JSON.stringify({ tags: ["tag1"] })),
+			});
+
+			const result = await runHandler(event);
+
+			expect(result.statusCode).toBe(200);
+			expect(mockTagCache.getByTag).toHaveBeenCalledWith("tag1");
+			expect(mockTagCache.writeTags).toHaveBeenCalled();
+		});
+
+		it("should invalidate CDN for soft tags in original mode", async () => {
+			mockTagCache.mode = "original";
+			mockTagCache.getByTag.mockResolvedValue(["/some-path"]);
+			mockTagCache.getByPath.mockResolvedValue([]);
+			const event = createEvent({
+				rawPath: "/cache/revalidate-tags",
+				method: "POST",
+				body: Buffer.from(JSON.stringify({ tags: ["_N_T_//some-path"] })),
+			});
+
+			await runHandler(event);
+
+			expect(mockCdnInvalidationHandler.invalidatePaths).toHaveBeenCalled();
+		});
+
+		it("should return 500 when revalidation fails", async () => {
+			mockTagCache.mode = "original";
+			mockTagCache.getByTag.mockRejectedValue(new Error("tag error"));
+			const event = createEvent({
+				rawPath: "/cache/revalidate-tags",
+				method: "POST",
+				body: Buffer.from(JSON.stringify({ tags: ["tag1"] })),
+			});
+
+			const result = await runHandler(event);
+
+			expect(result.statusCode).toBe(500);
+		});
+	});
+});

--- a/packages/tests-unit/tests/adapters/cache.test.ts
+++ b/packages/tests-unit/tests/adapters/cache.test.ts
@@ -1,5 +1,30 @@
-import Cache, { SOFT_TAG_PREFIX } from "@opennextjs/core/adapters/cache.js";
-import { type Mock, vi } from "vitest";
+import Cache from "@opennextjs/core/adapters/cache.js";
+import { vi } from "vitest";
+
+const cache = {
+	name: "mock",
+	get: vi.fn().mockResolvedValue({
+		value: {
+			type: "route",
+			body: "{}",
+		},
+		lastModified: Date.now(),
+	}),
+	set: vi.fn(),
+	delete: vi.fn(),
+	revalidateTags: vi.fn(),
+};
+globalThis.cache = cache;
+
+globalThis.__openNextAls = {
+	getStore: vi.fn().mockReturnValue({
+		pendingPromiseRunner: {
+			withResolvers: vi.fn().mockReturnValue({
+				resolve: vi.fn(),
+			}),
+		},
+	}),
+};
 
 declare global {
 	var openNextConfig: {
@@ -9,59 +34,16 @@ declare global {
 }
 
 describe("CacheHandler", () => {
-	let cache: Cache;
+	let instance: Cache;
 
 	vi.useFakeTimers().setSystemTime("2024-01-02T00:00:00Z");
 	const getFetchCacheSpy = vi.spyOn(Cache.prototype, "getFetchCache");
 	const getIncrementalCache = vi.spyOn(Cache.prototype, "getIncrementalCache");
 
-	const incrementalCache = {
-		name: "mock",
-		get: vi.fn().mockResolvedValue({
-			value: {
-				type: "route",
-				body: "{}",
-			},
-			lastModified: Date.now(),
-		}),
-		set: vi.fn(),
-		delete: vi.fn(),
-	};
-	globalThis.incrementalCache = incrementalCache;
-
-	const tagCache = {
-		name: "mock",
-		mode: "original",
-		hasBeenRevalidated: vi.fn(),
-		getByTag: vi.fn(),
-		getByPath: vi.fn(),
-		getLastModified: vi.fn().mockResolvedValue(new Date("2024-01-02T00:00:00Z").getTime()),
-		writeTags: vi.fn(),
-		getPathsByTags: undefined as Mock | undefined,
-	};
-	globalThis.tagCache = tagCache;
-
-	const invalidateCdnHandler = {
-		name: "mock",
-		invalidatePaths: vi.fn(),
-	};
-	globalThis.cdnInvalidationHandler = invalidateCdnHandler;
-
-	globalThis.__openNextAls = {
-		getStore: vi.fn().mockReturnValue({
-			pendingPromiseRunner: {
-				withResolvers: vi.fn().mockReturnValue({
-					resolve: vi.fn(),
-				}),
-			},
-			writtenTags: new Set(),
-		}),
-	};
-
 	beforeEach(() => {
 		vi.clearAllMocks();
 
-		cache = new Cache();
+		instance = new Cache();
 
 		globalThis.openNextConfig = {
 			dangerous: {
@@ -69,15 +51,13 @@ describe("CacheHandler", () => {
 			},
 		};
 		globalThis.isNextAfter15 = false;
-		tagCache.mode = "original";
-		tagCache.getPathsByTags = undefined;
 	});
 
 	describe("get", () => {
 		it("Should return null for cache miss", async () => {
-			incrementalCache.get.mockResolvedValueOnce({});
+			cache.get.mockResolvedValueOnce({});
 
-			const result = await cache.get("key");
+			const result = await instance.get("key");
 
 			expect(result).toBeNull();
 		});
@@ -88,68 +68,51 @@ describe("CacheHandler", () => {
 			});
 
 			it("Should return null when incremental cache is disabled", async () => {
-				const result = await cache.get("key");
+				const result = await instance.get("key");
 
 				expect(result).toBeNull();
 			});
 
 			it("Should not set cache when incremental cache is disabled", async () => {
-				globalThis.openNextConfig.dangerous.disableIncrementalCache = true;
+				await instance.set("key", { kind: "REDIRECT", props: {} });
 
-				await cache.set("key", { kind: "REDIRECT", props: {} });
-
-				expect(incrementalCache.set).not.toHaveBeenCalled();
+				expect(cache.set).not.toHaveBeenCalled();
 			});
 
 			it("Should not delete cache when incremental cache is disabled", async () => {
-				globalThis.openNextConfig.dangerous.disableIncrementalCache = true;
+				await instance.set("key", undefined);
 
-				await cache.set("key", undefined);
-
-				expect(incrementalCache.delete).not.toHaveBeenCalled();
+				expect(cache.delete).not.toHaveBeenCalled();
 			});
 		});
 
 		describe("fetch cache", () => {
 			it("Should retrieve cache from fetch cache when hint is fetch (next14)", async () => {
-				await cache.get("key", { kindHint: "fetch" });
+				await instance.get("key", { kindHint: "fetch" });
 
 				expect(getFetchCacheSpy).toHaveBeenCalled();
 			});
 
 			describe("next15", () => {
 				it("Should retrieve cache from fetch cache when hint is fetch", async () => {
-					await cache.get("key", { kind: "FETCH" });
+					await instance.get("key", { kind: "FETCH" });
 
 					expect(getFetchCacheSpy).toHaveBeenCalled();
 				});
 
-				it("Should return null when tag cache last modified is -1", async () => {
-					tagCache.getLastModified.mockResolvedValueOnce(-1);
+				it("Should return null when fetch cache entry is not found", async () => {
+					cache.get.mockResolvedValueOnce(null);
 
-					const result = await cache.get("key", { kind: "FETCH" });
+					const result = await instance.get("key", { kind: "FETCH" });
 
 					expect(getFetchCacheSpy).toHaveBeenCalled();
-					expect(result).toBeNull();
-				});
-
-				it("Should return null with nextMode tag cache that has been revalidated", async () => {
-					tagCache.mode = "nextMode";
-					tagCache.hasBeenRevalidated.mockResolvedValueOnce(true);
-
-					const result = await cache.get("key", {
-						kind: "FETCH",
-						tags: ["tag"],
-					});
-					expect(getFetchCacheSpy).toHaveBeenCalled();
-					expect(tagCache.hasBeenRevalidated).toHaveBeenCalled();
 					expect(result).toBeNull();
 				});
 
 				it("Should return null when incremental cache throws", async () => {
-					incrementalCache.get.mockRejectedValueOnce(new Error("Error retrieving cache"));
+					cache.get.mockRejectedValueOnce(new Error("Error retrieving cache"));
 
-					const result = await cache.get("key", { kind: "FETCH" });
+					const result = await instance.get("key", { kind: "FETCH" });
 
 					expect(getFetchCacheSpy).toHaveBeenCalled();
 					expect(result).toBeNull();
@@ -161,51 +124,14 @@ describe("CacheHandler", () => {
 			it.each(["app", "pages", undefined])(
 				"Should retrieve cache from incremental cache when hint is not fetch: %s",
 				async (kindHint) => {
-					await cache.get("key", { kindHint: kindHint as any });
+					await instance.get("key", { kindHint: kindHint as any });
 
 					expect(getIncrementalCache).toHaveBeenCalled();
 				}
 			);
 
-			it("Should return null when tag cache last modified is -1", async () => {
-				incrementalCache.get.mockResolvedValueOnce({
-					value: {
-						type: "route",
-					},
-					lastModified: Date.now(),
-				});
-				tagCache.getLastModified.mockResolvedValueOnce(-1);
-
-				const result = await cache.get("key", { kindHint: "app" });
-
-				expect(getIncrementalCache).toHaveBeenCalled();
-				expect(result).toBeNull();
-			});
-
-			it("Should return null with nextMode tag cache that has been revalidated", async () => {
-				tagCache.mode = "nextMode";
-				tagCache.hasBeenRevalidated.mockResolvedValueOnce(true);
-				incrementalCache.get.mockResolvedValueOnce({
-					value: {
-						type: "route",
-						meta: {
-							headers: {
-								"x-next-cache-tags": "tag",
-							},
-						},
-					},
-					lastModified: Date.now(),
-				});
-
-				const result = await cache.get("key", { kindHint: "app" });
-
-				expect(getIncrementalCache).toHaveBeenCalled();
-				expect(tagCache.hasBeenRevalidated).toHaveBeenCalled();
-				expect(result).toBeNull();
-			});
-
 			it("Should return value when cache data type is route", async () => {
-				incrementalCache.get.mockResolvedValueOnce({
+				cache.get.mockResolvedValueOnce({
 					value: {
 						type: "route",
 						body: "{}",
@@ -213,7 +139,7 @@ describe("CacheHandler", () => {
 					lastModified: Date.now(),
 				});
 
-				const result = await cache.get("key", { kindHint: "app" });
+				const result = await instance.get("key", { kindHint: "app" });
 
 				expect(getIncrementalCache).toHaveBeenCalled();
 				expect(result).toEqual({
@@ -226,7 +152,7 @@ describe("CacheHandler", () => {
 			});
 
 			it("Should return base64 encoded value when cache data type is route and content is binary", async () => {
-				incrementalCache.get.mockResolvedValueOnce({
+				cache.get.mockResolvedValueOnce({
 					value: {
 						type: "route",
 						body: Buffer.from("hello").toString("base64"),
@@ -239,7 +165,7 @@ describe("CacheHandler", () => {
 					lastModified: Date.now(),
 				});
 
-				const result = await cache.get("key", { kindHint: "app" });
+				const result = await instance.get("key", { kindHint: "app" });
 
 				expect(getIncrementalCache).toHaveBeenCalled();
 				expect(result).toEqual({
@@ -255,7 +181,7 @@ describe("CacheHandler", () => {
 			});
 
 			it("Should return value when cache data type is app", async () => {
-				incrementalCache.get.mockResolvedValueOnce({
+				cache.get.mockResolvedValueOnce({
 					value: {
 						type: "app",
 						html: "<html></html>",
@@ -267,7 +193,7 @@ describe("CacheHandler", () => {
 					lastModified: Date.now(),
 				});
 
-				const result = await cache.get("key", { kindHint: "app" });
+				const result = await instance.get("key", { kindHint: "app" });
 
 				expect(getIncrementalCache).toHaveBeenCalled();
 				expect(result).toEqual({
@@ -285,7 +211,7 @@ describe("CacheHandler", () => {
 			});
 
 			it("Should return value when cache data type is page", async () => {
-				incrementalCache.get.mockResolvedValueOnce({
+				cache.get.mockResolvedValueOnce({
 					value: {
 						type: "page",
 						html: "<html></html>",
@@ -297,7 +223,7 @@ describe("CacheHandler", () => {
 					lastModified: Date.now(),
 				});
 
-				const result = await cache.get("key", { kindHint: "pages" });
+				const result = await instance.get("key", { kindHint: "pages" });
 
 				expect(getIncrementalCache).toHaveBeenCalled();
 				expect(result).toEqual({
@@ -314,7 +240,7 @@ describe("CacheHandler", () => {
 
 			it("Should return value when cache data type is app with segmentData and postponed (Next 15+)", async () => {
 				globalThis.isNextAfter15 = true;
-				incrementalCache.get.mockResolvedValueOnce({
+				cache.get.mockResolvedValueOnce({
 					value: {
 						type: "app",
 						html: "<html></html>",
@@ -332,87 +258,7 @@ describe("CacheHandler", () => {
 					lastModified: Date.now(),
 				});
 
-				const result = await cache.get("key", { kindHint: "app" });
-
-				expect(getIncrementalCache).toHaveBeenCalled();
-				expect(result).toEqual({
-					value: {
-						kind: "APP_PAGE",
-						html: "<html></html>",
-						rscData: Buffer.from("rsc-data"),
-						status: 200,
-						headers: { "x-custom": "value" },
-						postponed: "postponed-data",
-						segmentData: new Map([
-							["segment1", Buffer.from("data1")],
-							["segment2", Buffer.from("data2")],
-						]),
-					},
-					lastModified: Date.now(),
-				});
-			});
-
-			it("Should return value when cache data type is app with segmentData and postponed (Next 15+)", async () => {
-				globalThis.isNextAfter15 = true;
-				incrementalCache.get.mockResolvedValueOnce({
-					value: {
-						type: "app",
-						html: "<html></html>",
-						rsc: "rsc-data",
-						segmentData: {
-							segment1: "data1",
-							segment2: "data2",
-						},
-						meta: {
-							status: 200,
-							headers: { "x-custom": "value" },
-							postponed: "postponed-data",
-						},
-					},
-					lastModified: Date.now(),
-				});
-
-				const result = await cache.get("key", { kindHint: "app" });
-
-				expect(getIncrementalCache).toHaveBeenCalled();
-				expect(result).toEqual({
-					value: {
-						kind: "APP_PAGE",
-						html: "<html></html>",
-						rscData: Buffer.from("rsc-data"),
-						status: 200,
-						headers: { "x-custom": "value" },
-						postponed: "postponed-data",
-						segmentData: new Map([
-							["segment1", Buffer.from("data1")],
-							["segment2", Buffer.from("data2")],
-						]),
-					},
-					lastModified: Date.now(),
-				});
-			});
-
-			it("Should return value when cache data type is app with segmentData and postponed (Next 15+)", async () => {
-				globalThis.isNextAfter15 = true;
-				incrementalCache.get.mockResolvedValueOnce({
-					value: {
-						type: "app",
-						html: "<html></html>",
-						rsc: "rsc-data",
-						segmentData: {
-							segment1: "data1",
-							segment2: "data2",
-						},
-						meta: {
-							status: 200,
-							headers: { "x-custom": "value" },
-							postponed: "postponed-data",
-						},
-					},
-					lastModified: Date.now(),
-				});
-
-				const result = await cache.get("key", { kindHint: "app" });
+				const result = await instance.get("key", { kindHint: "app" });
 
 				expect(getIncrementalCache).toHaveBeenCalled();
 				expect(result).toEqual({
@@ -433,14 +279,14 @@ describe("CacheHandler", () => {
 			});
 
 			it("Should return value when cache data type is redirect", async () => {
-				incrementalCache.get.mockResolvedValueOnce({
+				cache.get.mockResolvedValueOnce({
 					value: {
 						type: "redirect",
 					},
 					lastModified: Date.now(),
 				});
 
-				const result = await cache.get("key", { kindHint: "app" });
+				const result = await instance.get("key", { kindHint: "app" });
 
 				expect(getIncrementalCache).toHaveBeenCalled();
 				expect(result).toEqual({
@@ -452,9 +298,9 @@ describe("CacheHandler", () => {
 			});
 
 			it("Should return null when incremental cache fails", async () => {
-				incrementalCache.get.mockRejectedValueOnce(new Error("Error"));
+				cache.get.mockRejectedValueOnce(new Error("Error"));
 
-				const result = await cache.get("key", { kindHint: "app" });
+				const result = await instance.get("key", { kindHint: "app" });
 
 				expect(getIncrementalCache).toHaveBeenCalled();
 				expect(result).toBeNull();
@@ -464,20 +310,20 @@ describe("CacheHandler", () => {
 
 	describe("set", () => {
 		it("Should delete cache when data is undefined", async () => {
-			await cache.set("key", undefined);
+			await instance.set("key", undefined);
 
-			expect(incrementalCache.delete).toHaveBeenCalled();
+			expect(cache.delete).toHaveBeenCalled();
 		});
 
 		it("Should set cache when for ROUTE", async () => {
-			await cache.set("key", {
+			await instance.set("key", {
 				kind: "ROUTE",
 				body: Buffer.from("{}"),
 				status: 200,
 				headers: {},
 			});
 
-			expect(incrementalCache.set).toHaveBeenCalledWith(
+			expect(cache.set).toHaveBeenCalledWith(
 				"key",
 				{ type: "route", body: "{}", meta: { status: 200, headers: {} } },
 				"cache"
@@ -485,7 +331,7 @@ describe("CacheHandler", () => {
 		});
 
 		it("Should set cache when for APP_ROUTE", async () => {
-			await cache.set("key", {
+			await instance.set("key", {
 				kind: "APP_ROUTE",
 				body: Buffer.from("{}"),
 				status: 200,
@@ -494,7 +340,7 @@ describe("CacheHandler", () => {
 				},
 			});
 
-			expect(incrementalCache.set).toHaveBeenCalledWith(
+			expect(cache.set).toHaveBeenCalledWith(
 				"key",
 				{
 					type: "route",
@@ -506,7 +352,7 @@ describe("CacheHandler", () => {
 		});
 
 		it("Should set cache when for PAGE", async () => {
-			await cache.set("key", {
+			await instance.set("key", {
 				kind: "PAGE",
 				html: "<html></html>",
 				pageData: {},
@@ -514,7 +360,7 @@ describe("CacheHandler", () => {
 				headers: {},
 			});
 
-			expect(incrementalCache.set).toHaveBeenCalledWith(
+			expect(cache.set).toHaveBeenCalledWith(
 				"key",
 				{
 					type: "page",
@@ -526,7 +372,7 @@ describe("CacheHandler", () => {
 		});
 
 		it("Should set cache when for PAGES", async () => {
-			await cache.set("key", {
+			await instance.set("key", {
 				kind: "PAGES",
 				html: "<html></html>",
 				pageData: "rsc",
@@ -534,7 +380,7 @@ describe("CacheHandler", () => {
 				headers: {},
 			});
 
-			expect(incrementalCache.set).toHaveBeenCalledWith(
+			expect(cache.set).toHaveBeenCalledWith(
 				"key",
 				{
 					type: "app",
@@ -547,7 +393,7 @@ describe("CacheHandler", () => {
 		});
 
 		it("Should set cache when for APP_PAGE", async () => {
-			await cache.set("key", {
+			await instance.set("key", {
 				kind: "APP_PAGE",
 				html: "<html></html>",
 				rscData: Buffer.from("rsc"),
@@ -555,7 +401,7 @@ describe("CacheHandler", () => {
 				headers: {},
 			});
 
-			expect(incrementalCache.set).toHaveBeenCalledWith(
+			expect(cache.set).toHaveBeenCalledWith(
 				"key",
 				{
 					type: "app",
@@ -573,7 +419,7 @@ describe("CacheHandler", () => {
 				["segment2", Buffer.from("data2")],
 			]);
 
-			await cache.set("key", {
+			await instance.set("key", {
 				kind: "APP_PAGE",
 				html: "<html></html>",
 				rscData: Buffer.from("rsc"),
@@ -583,7 +429,7 @@ describe("CacheHandler", () => {
 				postponed: "postponed-data",
 			});
 
-			expect(incrementalCache.set).toHaveBeenCalledWith(
+			expect(cache.set).toHaveBeenCalledWith(
 				"key",
 				{
 					type: "app",
@@ -604,7 +450,7 @@ describe("CacheHandler", () => {
 		});
 
 		it("Should set cache when for FETCH", async () => {
-			await cache.set("key", {
+			await instance.set("key", {
 				kind: "FETCH",
 				data: {
 					headers: {},
@@ -616,7 +462,7 @@ describe("CacheHandler", () => {
 				revalidate: 60,
 			});
 
-			expect(incrementalCache.set).toHaveBeenCalledWith(
+			expect(cache.set).toHaveBeenCalledWith(
 				"key",
 				{
 					kind: "FETCH",
@@ -634,9 +480,9 @@ describe("CacheHandler", () => {
 		});
 
 		it("Should set cache when for REDIRECT", async () => {
-			await cache.set("key", { kind: "REDIRECT", props: {} });
+			await instance.set("key", { kind: "REDIRECT", props: {} });
 
-			expect(incrementalCache.set).toHaveBeenCalledWith(
+			expect(cache.set).toHaveBeenCalledWith(
 				"key",
 				{
 					type: "redirect",
@@ -647,20 +493,20 @@ describe("CacheHandler", () => {
 		});
 
 		it("Should not set cache when for IMAGE (not implemented)", async () => {
-			await cache.set("key", {
+			await instance.set("key", {
 				kind: "IMAGE",
 				etag: "etag",
 				buffer: Buffer.from("hello"),
 				extension: "png",
 			});
 
-			expect(incrementalCache.set).not.toHaveBeenCalled();
+			expect(cache.set).not.toHaveBeenCalled();
 		});
 
 		it("Should not throw when set cache throws", async () => {
-			incrementalCache.set.mockRejectedValueOnce(new Error("Error"));
+			cache.set.mockRejectedValueOnce(new Error("Error"));
 
-			await expect(cache.set("key", { kind: "REDIRECT", props: {} })).resolves.not.toThrow();
+			await expect(instance.set("key", { kind: "REDIRECT", props: {} })).resolves.not.toThrow();
 		});
 	});
 
@@ -669,304 +515,45 @@ describe("CacheHandler", () => {
 			globalThis.openNextConfig.dangerous.disableTagCache = false;
 			globalThis.openNextConfig.dangerous.disableIncrementalCache = false;
 		});
+
 		it("Should do nothing if disableIncrementalCache is true", async () => {
 			globalThis.openNextConfig.dangerous.disableIncrementalCache = true;
 
-			await cache.revalidateTag("tag");
+			await instance.revalidateTag("tag");
 
-			expect(tagCache.writeTags).not.toHaveBeenCalled();
+			expect(cache.revalidateTags).not.toHaveBeenCalled();
 		});
 
 		it("Should do nothing if disableTagCache is true", async () => {
 			globalThis.openNextConfig.dangerous.disableTagCache = true;
 
-			await cache.revalidateTag("tag");
+			await instance.revalidateTag("tag");
 
-			expect(tagCache.writeTags).not.toHaveBeenCalled();
-			// Reset the config
-			globalThis.openNextConfig.dangerous.disableTagCache = false;
+			expect(cache.revalidateTags).not.toHaveBeenCalled();
 		});
 
-		it("Should call tagCache.writeTags", async () => {
-			tagCache.getByTag.mockResolvedValueOnce(["/path"]);
-			await cache.revalidateTag("tag");
+		it("Should call cache.revalidateTags with single tag", async () => {
+			await instance.revalidateTag("tag");
 
-			expect(tagCache.getByTag).toHaveBeenCalledWith("tag");
-
-			expect(tagCache.writeTags).toHaveBeenCalledTimes(1);
-			expect(tagCache.writeTags).toHaveBeenCalledWith([
-				{
-					path: "/path",
-					tag: "tag",
-				},
-			]);
+			expect(cache.revalidateTags).toHaveBeenCalledWith(["tag"]);
 		});
 
-		it("Should call invalidateCdnHandler.invalidatePaths", async () => {
-			tagCache.getByTag.mockResolvedValueOnce(["/path"]);
-			tagCache.getByPath.mockResolvedValueOnce([]);
-			await cache.revalidateTag(`${SOFT_TAG_PREFIX}path`);
+		it("Should call cache.revalidateTags with array of tags", async () => {
+			await instance.revalidateTag(["tag1", "tag2"]);
 
-			expect(tagCache.writeTags).toHaveBeenCalledTimes(1);
-			expect(tagCache.writeTags).toHaveBeenCalledWith([
-				{
-					path: "/path",
-					tag: `${SOFT_TAG_PREFIX}path`,
-				},
-			]);
-
-			expect(invalidateCdnHandler.invalidatePaths).toHaveBeenCalled();
+			expect(cache.revalidateTags).toHaveBeenCalledWith(["tag1", "tag2"]);
 		});
 
-		it("Should not call invalidateCdnHandler.invalidatePaths for fetch cache key ", async () => {
-			tagCache.getByTag.mockResolvedValueOnce(["123456"]);
-			await cache.revalidateTag("tag");
+		it("Should not call cache.revalidateTags when tags array is empty", async () => {
+			await instance.revalidateTag([]);
 
-			expect(tagCache.writeTags).toHaveBeenCalledTimes(1);
-			expect(tagCache.writeTags).toHaveBeenCalledWith([
-				{
-					path: "123456",
-					tag: "tag",
-				},
-			]);
-
-			expect(invalidateCdnHandler.invalidatePaths).not.toHaveBeenCalled();
+			expect(cache.revalidateTags).not.toHaveBeenCalled();
 		});
 
-		it("Should only call writeTags for nextMode", async () => {
-			tagCache.mode = "nextMode";
-			await cache.revalidateTag(["tag1", "tag2"]);
+		it("Should not throw when revalidateTags fails", async () => {
+			cache.revalidateTags.mockRejectedValueOnce(new Error("Error"));
 
-			expect(tagCache.writeTags).toHaveBeenCalledTimes(1);
-			expect(tagCache.writeTags).toHaveBeenCalledWith(["tag1", "tag2"]);
-			expect(invalidateCdnHandler.invalidatePaths).not.toHaveBeenCalled();
-		});
-
-		it("Should not call writeTags when the tag list is empty for nextMode", async () => {
-			tagCache.mode = "nextMode";
-			await cache.revalidateTag([]);
-
-			expect(tagCache.writeTags).not.toHaveBeenCalled();
-			expect(invalidateCdnHandler.invalidatePaths).not.toHaveBeenCalled();
-		});
-
-		it("Should call writeTags and invalidateCdnHandler.invalidatePaths for nextMode that supports getPathsByTags", async () => {
-			tagCache.mode = "nextMode";
-			tagCache.getPathsByTags = vi.fn().mockResolvedValueOnce(["/path"]);
-			await cache.revalidateTag("tag");
-
-			expect(tagCache.writeTags).toHaveBeenCalledTimes(1);
-			expect(tagCache.writeTags).toHaveBeenCalledWith(["tag"]);
-			expect(invalidateCdnHandler.invalidatePaths).toHaveBeenCalledWith([
-				{
-					initialPath: "/path",
-					rawPath: "/path",
-					resolvedRoutes: [
-						{
-							type: "app",
-							route: "/path",
-							isFallback: false,
-						},
-					],
-				},
-			]);
-		});
-	});
-
-	describe("shouldBypassTagCache", () => {
-		describe("fetch cache", () => {
-			it("Should bypass tag cache validation when shouldBypassTagCache is true", async () => {
-				incrementalCache.get.mockResolvedValueOnce({
-					value: {
-						kind: "FETCH",
-						data: {
-							headers: {},
-							body: "{}",
-							url: "https://example.com",
-							status: 200,
-						},
-					},
-					lastModified: Date.now(),
-					shouldBypassTagCache: true,
-				});
-
-				const result = await cache.get("key", {
-					kind: "FETCH",
-					tags: ["tag1"],
-				});
-
-				expect(getFetchCacheSpy).toHaveBeenCalled();
-				expect(tagCache.getLastModified).not.toHaveBeenCalled();
-				expect(tagCache.hasBeenRevalidated).not.toHaveBeenCalled();
-				expect(result).not.toBeNull();
-				expect(result?.value).toEqual({
-					kind: "FETCH",
-					data: {
-						headers: {},
-						body: "{}",
-						url: "https://example.com",
-						status: 200,
-					},
-				});
-			});
-
-			it("Should not bypass tag cache validation when shouldBypassTagCache is false", async () => {
-				tagCache.mode = "nextMode";
-				incrementalCache.get.mockResolvedValueOnce({
-					value: {
-						kind: "FETCH",
-						data: {
-							headers: {},
-							body: "{}",
-							url: "https://example.com",
-							status: 200,
-						},
-					},
-					lastModified: Date.now(),
-					shouldBypassTagCache: false,
-				});
-
-				const result = await cache.get("key", {
-					kind: "FETCH",
-					tags: ["tag1"],
-				});
-
-				expect(getFetchCacheSpy).toHaveBeenCalled();
-				expect(tagCache.hasBeenRevalidated).toHaveBeenCalled();
-				expect(result).not.toBeNull();
-			});
-
-			it("Should not bypass tag cache validation when shouldBypassTagCache is undefined", async () => {
-				tagCache.mode = "nextMode";
-				tagCache.hasBeenRevalidated.mockResolvedValueOnce(false);
-				incrementalCache.get.mockResolvedValueOnce({
-					value: {
-						kind: "FETCH",
-						data: {
-							headers: {},
-							body: "{}",
-							url: "https://example.com",
-							status: 200,
-						},
-					},
-					lastModified: Date.now(),
-					// shouldBypassTagCache not set
-				});
-
-				const result = await cache.get("key", {
-					kind: "FETCH",
-					tags: ["tag1"],
-				});
-
-				expect(getFetchCacheSpy).toHaveBeenCalled();
-				expect(tagCache.hasBeenRevalidated).toHaveBeenCalled();
-				expect(result).not.toBeNull();
-			});
-
-			it("Should bypass path validation when shouldBypassTagCache is true for soft tags", async () => {
-				incrementalCache.get.mockResolvedValueOnce({
-					value: {
-						kind: "FETCH",
-						data: {
-							headers: {},
-							body: "{}",
-							url: "https://example.com",
-							status: 200,
-						},
-					},
-					lastModified: Date.now(),
-					shouldBypassTagCache: true,
-				});
-
-				const result = await cache.get("key", {
-					kind: "FETCH",
-					softTags: [`${SOFT_TAG_PREFIX}path`],
-				});
-
-				expect(getFetchCacheSpy).toHaveBeenCalled();
-				expect(tagCache.getLastModified).not.toHaveBeenCalled();
-				expect(tagCache.hasBeenRevalidated).not.toHaveBeenCalled();
-				expect(result).not.toBeNull();
-			});
-		});
-
-		describe("incremental cache", () => {
-			it("Should bypass tag cache validation when shouldBypassTagCache is true", async () => {
-				incrementalCache.get.mockResolvedValueOnce({
-					value: {
-						type: "route",
-						body: "{}",
-					},
-					lastModified: Date.now(),
-					shouldBypassTagCache: true,
-				});
-
-				const result = await cache.get("key", { kindHint: "app" });
-
-				expect(getIncrementalCache).toHaveBeenCalled();
-				expect(tagCache.getLastModified).not.toHaveBeenCalled();
-				expect(tagCache.hasBeenRevalidated).not.toHaveBeenCalled();
-				expect(result).not.toBeNull();
-				expect(result?.value?.kind).toEqual("APP_ROUTE");
-			});
-
-			it("Should not bypass tag cache validation when shouldBypassTagCache is false", async () => {
-				tagCache.mode = "nextMode";
-				incrementalCache.get.mockResolvedValueOnce({
-					value: {
-						type: "route",
-						body: "{}",
-						meta: { headers: { "x-next-cache-tags": "tag" } },
-					},
-					lastModified: Date.now(),
-					shouldBypassTagCache: false,
-				});
-
-				const result = await cache.get("key", { kindHint: "app" });
-
-				expect(getIncrementalCache).toHaveBeenCalled();
-				expect(tagCache.hasBeenRevalidated).toHaveBeenCalled();
-				expect(result).not.toBeNull();
-			});
-
-			it("Should return null when tag cache indicates revalidation and shouldBypassTagCache is false", async () => {
-				tagCache.mode = "nextMode";
-				tagCache.hasBeenRevalidated.mockResolvedValueOnce(true);
-				incrementalCache.get.mockResolvedValueOnce({
-					value: {
-						type: "route",
-						body: "{}",
-						meta: { headers: { "x-next-cache-tags": "tag" } },
-					},
-					lastModified: Date.now(),
-					shouldBypassTagCache: false,
-				});
-
-				const result = await cache.get("key", { kindHint: "app" });
-
-				expect(getIncrementalCache).toHaveBeenCalled();
-				expect(tagCache.hasBeenRevalidated).toHaveBeenCalled();
-				expect(result).toBeNull();
-			});
-
-			it("Should return value when tag cache indicates revalidation but shouldBypassTagCache is true", async () => {
-				incrementalCache.get.mockResolvedValueOnce({
-					value: {
-						type: "route",
-						body: "{}",
-					},
-					lastModified: Date.now(),
-					shouldBypassTagCache: true,
-				});
-
-				const result = await cache.get("key", { kindHint: "app" });
-
-				expect(getIncrementalCache).toHaveBeenCalled();
-				expect(tagCache.getLastModified).not.toHaveBeenCalled();
-				expect(tagCache.hasBeenRevalidated).not.toHaveBeenCalled();
-				expect(result).not.toBeNull();
-				expect(result?.value?.kind).toEqual("APP_ROUTE");
-			});
+			await expect(instance.revalidateTag("tag")).resolves.not.toThrow();
 		});
 	});
 });

--- a/packages/tests-unit/tests/adapters/composable-cache.test.ts
+++ b/packages/tests-unit/tests/adapters/composable-cache.test.ts
@@ -2,58 +2,40 @@ import ComposableCache from "@opennextjs/core/adapters/composable-cache";
 import { fromReadableStream, toReadableStream } from "@opennextjs/core/utils/stream";
 import { vi } from "vitest";
 
+const cache = {
+	name: "mock",
+	get: vi.fn().mockResolvedValue({
+		value: {
+			type: "route",
+			body: "{}",
+			tags: ["tag1", "tag2"],
+			stale: 0,
+			timestamp: Date.now(),
+			expire: Date.now() + 1000,
+			revalidate: 3600,
+			value: "test-value",
+		},
+		lastModified: Date.now(),
+	}),
+	set: vi.fn(),
+	delete: vi.fn(),
+	revalidateTags: vi.fn(),
+};
+globalThis.cache = cache;
+
+globalThis.__openNextAls = {
+	getStore: () => ({
+		pendingPromiseRunner: {
+			withResolvers: vi.fn().mockReturnValue({
+				resolve: vi.fn(),
+			}),
+		},
+		writtenTags: new Set(),
+	}),
+};
+
 describe("Composable cache handler", () => {
 	vi.useFakeTimers().setSystemTime("2024-01-02T00:00:00Z");
-
-	const incrementalCache = {
-		name: "mock",
-		get: vi.fn().mockResolvedValue({
-			value: {
-				type: "route",
-				body: "{}",
-				tags: ["tag1", "tag2"],
-				stale: 0,
-				timestamp: Date.now(),
-				expire: Date.now() + 1000,
-				revalidate: 3600,
-				value: "test-value",
-			},
-			lastModified: Date.now(),
-		}),
-		set: vi.fn(),
-		delete: vi.fn(),
-	};
-	globalThis.incrementalCache = incrementalCache;
-
-	const tagCache = {
-		name: "mock",
-		mode: "original" as string | undefined,
-		hasBeenRevalidated: vi.fn(),
-		getByTag: vi.fn().mockResolvedValue(["path1", "path2"]),
-		getByPath: vi.fn().mockResolvedValue(["tag1"]),
-		getLastModified: vi.fn().mockResolvedValue(new Date("2024-01-02T00:00:00Z").getTime()),
-		getLastRevalidated: vi.fn().mockResolvedValue(0),
-		writeTags: vi.fn(),
-	};
-	globalThis.tagCache = tagCache;
-
-	const invalidateCdnHandler = {
-		name: "mock",
-		invalidatePaths: vi.fn(),
-	};
-	globalThis.cdnInvalidationHandler = invalidateCdnHandler;
-	const writtenTags = new Set();
-
-	globalThis.__openNextAls = {
-		getStore: () => ({
-			pendingPromiseRunner: {
-				withResolvers: vi.fn().mockReturnValue({
-					resolve: vi.fn(),
-				}),
-			},
-			writtenTags,
-		}),
-	};
 
 	beforeEach(() => {
 		vi.clearAllMocks();
@@ -67,17 +49,17 @@ describe("Composable cache handler", () => {
 	});
 
 	describe("get", () => {
-		it("should return cached entry when available and not revalidated", async () => {
+		it("should return cached entry when available", async () => {
 			const result = await ComposableCache.get("test-key");
 
-			expect(incrementalCache.get).toHaveBeenCalledWith("test-key", "composable");
+			expect(cache.get).toHaveBeenCalledWith("test-key", "composable");
 			expect(result).toBeDefined();
 			expect(result?.tags).toEqual(["tag1", "tag2"]);
 			expect(result?.value).toBeInstanceOf(ReadableStream);
 		});
 
 		it("should return undefined when cache entry does not exist", async () => {
-			incrementalCache.get.mockResolvedValueOnce(null);
+			cache.get.mockResolvedValueOnce(null);
 
 			const result = await ComposableCache.get("non-existent-key");
 
@@ -85,7 +67,7 @@ describe("Composable cache handler", () => {
 		});
 
 		it("should return undefined when cache entry has no value", async () => {
-			incrementalCache.get.mockResolvedValueOnce({
+			cache.get.mockResolvedValueOnce({
 				value: null,
 				lastModified: Date.now(),
 			});
@@ -95,74 +77,8 @@ describe("Composable cache handler", () => {
 			expect(result).toBeUndefined();
 		});
 
-		it("should check tag revalidation in nextMode", async () => {
-			tagCache.mode = "nextMode";
-			tagCache.hasBeenRevalidated.mockResolvedValueOnce(false);
-
-			const result = await ComposableCache.get("test-key");
-
-			expect(tagCache.hasBeenRevalidated).toHaveBeenCalledWith(["tag1", "tag2"], expect.any(Number));
-			expect(result).toBeDefined();
-		});
-
-		it("should return undefined when tags have been revalidated in nextMode", async () => {
-			tagCache.mode = "nextMode";
-			tagCache.hasBeenRevalidated.mockResolvedValueOnce(true);
-
-			const result = await ComposableCache.get("test-key");
-
-			expect(result).toBeUndefined();
-		});
-
-		it("should skip tag check when tags array is empty in nextMode", async () => {
-			tagCache.mode = "nextMode";
-			incrementalCache.get.mockResolvedValueOnce({
-				value: {
-					type: "route",
-					body: "{}",
-					tags: [],
-					value: "test-value",
-				},
-				lastModified: Date.now(),
-			});
-
-			const result = await ComposableCache.get("test-key");
-
-			expect(tagCache.hasBeenRevalidated).not.toHaveBeenCalled();
-			expect(result).toBeDefined();
-		});
-
-		it("should check last modified in original mode", async () => {
-			tagCache.mode = "original";
-			tagCache.getLastModified.mockResolvedValueOnce(Date.now());
-
-			const result = await ComposableCache.get("test-key");
-
-			expect(tagCache.getLastModified).toHaveBeenCalledWith("test-key", expect.any(Number));
-			expect(result).toBeDefined();
-		});
-
-		it("should return undefined when entry has been revalidated in original mode", async () => {
-			tagCache.mode = "original";
-			tagCache.getLastModified.mockResolvedValueOnce(-1);
-
-			const result = await ComposableCache.get("test-key");
-
-			expect(result).toBeUndefined();
-		});
-
-		it("should handle undefined tag cache mode", async () => {
-			tagCache.mode = undefined;
-			tagCache.getLastModified.mockResolvedValueOnce(Date.now());
-
-			const result = await ComposableCache.get("test-key");
-
-			expect(tagCache.getLastModified).toHaveBeenCalled();
-			expect(result).toBeDefined();
-		});
-
 		it("should return undefined on cache read error", async () => {
-			incrementalCache.get.mockRejectedValueOnce(new Error("Cache error"));
+			cache.get.mockRejectedValueOnce(new Error("Cache error"));
 
 			const result = await ComposableCache.get("test-key");
 
@@ -194,12 +110,7 @@ describe("Composable cache handler", () => {
 	});
 
 	describe("set", () => {
-		beforeEach(() => {
-			writtenTags.clear();
-		});
-
-		it("should set cache entry and handle tags in original mode", async () => {
-			tagCache.mode = "original";
+		it("should set cache entry", async () => {
 			const entry = {
 				value: toReadableStream("test-value"),
 				tags: ["tag1", "tag2"],
@@ -211,7 +122,7 @@ describe("Composable cache handler", () => {
 
 			await ComposableCache.set("test-key", Promise.resolve(entry));
 
-			expect(incrementalCache.set).toHaveBeenCalledWith(
+			expect(cache.set).toHaveBeenCalledWith(
 				"test-key",
 				expect.objectContaining({
 					tags: ["tag1", "tag2"],
@@ -219,64 +130,6 @@ describe("Composable cache handler", () => {
 				}),
 				"composable"
 			);
-			expect(tagCache.getByPath).toHaveBeenCalledWith("test-key");
-		});
-
-		it("should write new tags not already stored", async () => {
-			tagCache.mode = "original";
-			tagCache.getByPath.mockResolvedValueOnce(["tag1"]);
-
-			const entry = {
-				value: toReadableStream("test-value"),
-				tags: ["tag1", "tag2", "tag3"],
-				stale: 0,
-				timestamp: Date.now(),
-				expire: Date.now() + 1000,
-				revalidate: 3600,
-			};
-
-			await ComposableCache.set("test-key", Promise.resolve(entry));
-
-			expect(tagCache.writeTags).toHaveBeenCalledWith([
-				{ tag: "tag2", path: "test-key" },
-				{ tag: "tag3", path: "test-key" },
-			]);
-		});
-
-		it("should not write tags if all are already stored", async () => {
-			tagCache.mode = "original";
-			tagCache.getByPath.mockResolvedValueOnce(["tag1", "tag2"]);
-
-			const entry = {
-				value: toReadableStream("test-value"),
-				tags: ["tag1", "tag2"],
-				stale: 0,
-				timestamp: Date.now(),
-				expire: Date.now() + 1000,
-				revalidate: 3600,
-			};
-
-			await ComposableCache.set("test-key", Promise.resolve(entry));
-
-			expect(tagCache.writeTags).not.toHaveBeenCalled();
-		});
-
-		it("should skip tag handling in nextMode", async () => {
-			tagCache.mode = "nextMode";
-
-			const entry = {
-				value: toReadableStream("test-value"),
-				tags: ["tag1", "tag2"],
-				stale: 0,
-				timestamp: Date.now(),
-				expire: Date.now() + 1000,
-				revalidate: 3600,
-			};
-
-			await ComposableCache.set("test-key", Promise.resolve(entry));
-
-			expect(tagCache.getByPath).not.toHaveBeenCalled();
-			expect(tagCache.writeTags).not.toHaveBeenCalled();
 		});
 
 		it("should convert ReadableStream to string", async () => {
@@ -291,7 +144,7 @@ describe("Composable cache handler", () => {
 
 			await ComposableCache.set("test-key", Promise.resolve(entry));
 
-			expect(incrementalCache.set).toHaveBeenCalledWith(
+			expect(cache.set).toHaveBeenCalledWith(
 				"test-key",
 				expect.objectContaining({
 					value: "test-content",
@@ -306,131 +159,43 @@ describe("Composable cache handler", () => {
 			await ComposableCache.refreshTags();
 
 			// Should not call any methods
-			expect(incrementalCache.get).not.toHaveBeenCalled();
-			expect(incrementalCache.set).not.toHaveBeenCalled();
-			expect(tagCache.writeTags).not.toHaveBeenCalled();
+			expect(cache.get).not.toHaveBeenCalled();
+			expect(cache.set).not.toHaveBeenCalled();
+			expect(cache.revalidateTags).not.toHaveBeenCalled();
 		});
 	});
 
-	describe("getExpiration (Next 15)", () => {
-		it("should return last revalidated time in nextMode", async () => {
-			tagCache.mode = "nextMode";
-			tagCache.getLastRevalidated.mockResolvedValueOnce(123456);
-
-			const result = await ComposableCache.getExpiration("tag1", "tag2");
-
-			expect(tagCache.getLastRevalidated).toHaveBeenCalledWith(["tag1", "tag2"]);
-			expect(result).toBe(123456);
-		});
-
-		it("should return 0 in original mode", async () => {
-			tagCache.mode = "original";
-
+	describe("getExpiration", () => {
+		it("should return 0 regardless of arguments", async () => {
 			const result = await ComposableCache.getExpiration("tag1", "tag2");
 
 			expect(result).toBe(0);
 		});
 
-		it("should return 0 when mode is undefined", async () => {
-			tagCache.mode = undefined;
-
-			const result = await ComposableCache.getExpiration("tag1", "tag2");
-
-			expect(result).toBe(0);
-		});
-	});
-
-	describe("getExpiration (Next 16)", () => {
-		it("should return last revalidated time in nextMode", async () => {
-			tagCache.mode = "nextMode";
-			tagCache.getLastRevalidated.mockResolvedValueOnce(123456);
-
-			const result = await ComposableCache.getExpiration(["tag1", "tag2"]);
-
-			expect(tagCache.getLastRevalidated).toHaveBeenCalledWith(["tag1", "tag2"]);
-			expect(result).toBe(123456);
-		});
-
-		it("should return 0 in original mode", async () => {
-			tagCache.mode = "original";
-
+		it("should return 0 for array argument (Next 16 signature)", async () => {
 			const result = await ComposableCache.getExpiration(["tag1", "tag2"]);
 
 			expect(result).toBe(0);
 		});
 
-		it("should return 0 when mode is undefined", async () => {
-			tagCache.mode = undefined;
-
-			const result = await ComposableCache.getExpiration(["tag1", "tag2"]);
+		it("should return 0 for empty args", async () => {
+			const result = await ComposableCache.getExpiration();
 
 			expect(result).toBe(0);
 		});
 	});
 
 	describe("expireTags", () => {
-		beforeEach(() => {
-			writtenTags.clear();
-		});
-		it("should write tags directly in nextMode", async () => {
-			tagCache.mode = "nextMode";
-
+		it("should call cache.revalidateTags with flat tags array", async () => {
 			await ComposableCache.expireTags("tag1", "tag2");
 
-			expect(tagCache.writeTags).toHaveBeenCalledWith(["tag1", "tag2"]);
+			expect(cache.revalidateTags).toHaveBeenCalledWith(["tag1", "tag2"]);
 		});
 
-		it("should find paths and write tag mappings in original mode", async () => {
-			tagCache.mode = "original";
-			tagCache.getByTag.mockImplementation(async (tag) => {
-				if (tag === "tag1") return ["path1", "path2"];
-				if (tag === "tag2") return ["path2", "path3"];
-				return [];
-			});
+		it("should not call revalidateTags when no tags provided", async () => {
+			await ComposableCache.expireTags();
 
-			await ComposableCache.expireTags("tag1", "tag2");
-
-			expect(tagCache.getByTag).toHaveBeenCalledWith("tag1");
-			expect(tagCache.getByTag).toHaveBeenCalledWith("tag2");
-			expect(tagCache.writeTags).toHaveBeenCalledWith(
-				expect.arrayContaining([
-					{ path: "path1", tag: "tag1", revalidatedAt: expect.any(Number) },
-					{ path: "path2", tag: "tag1", revalidatedAt: expect.any(Number) },
-					{ path: "path2", tag: "tag2", revalidatedAt: expect.any(Number) },
-					{ path: "path3", tag: "tag2", revalidatedAt: expect.any(Number) },
-				])
-			);
-		});
-
-		it("should deduplicate paths in original mode", async () => {
-			tagCache.mode = "original";
-			tagCache.getByTag.mockImplementation(async (tag) => {
-				if (tag === "tag1") return ["path1", "path2"];
-				if (tag === "tag2") return ["path1", "path2"];
-				return [];
-			});
-
-			await ComposableCache.expireTags("tag1", "tag2");
-
-			const writtenTags = tagCache.writeTags.mock.calls[0][0];
-			expect(writtenTags).toHaveLength(4); // 2 paths × 2 tags = 4 unique combinations
-			expect(writtenTags).toEqual(
-				expect.arrayContaining([
-					{ path: "path1", tag: "tag1", revalidatedAt: expect.any(Number) },
-					{ path: "path2", tag: "tag1", revalidatedAt: expect.any(Number) },
-					{ path: "path1", tag: "tag2", revalidatedAt: expect.any(Number) },
-					{ path: "path2", tag: "tag2", revalidatedAt: expect.any(Number) },
-				])
-			);
-		});
-
-		it("should handle empty paths in original mode", async () => {
-			tagCache.mode = "original";
-			tagCache.getByTag.mockResolvedValue([]);
-
-			await ComposableCache.expireTags("tag1");
-
-			expect(tagCache.writeTags).not.toHaveBeenCalled();
+			expect(cache.revalidateTags).not.toHaveBeenCalled();
 		});
 	});
 
@@ -439,9 +204,9 @@ describe("Composable cache handler", () => {
 			await ComposableCache.receiveExpiredTags("tag1", "tag2");
 
 			// Should not call any methods
-			expect(incrementalCache.get).not.toHaveBeenCalled();
-			expect(incrementalCache.set).not.toHaveBeenCalled();
-			expect(tagCache.writeTags).not.toHaveBeenCalled();
+			expect(cache.get).not.toHaveBeenCalled();
+			expect(cache.set).not.toHaveBeenCalled();
+			expect(cache.revalidateTags).not.toHaveBeenCalled();
 		});
 	});
 
@@ -460,7 +225,7 @@ describe("Composable cache handler", () => {
 			await ComposableCache.set("integration-key", Promise.resolve(entry));
 
 			// Verify it was stored
-			expect(incrementalCache.set).toHaveBeenCalledWith(
+			expect(cache.set).toHaveBeenCalledWith(
 				"integration-key",
 				expect.objectContaining({
 					value: "integration-test",
@@ -470,7 +235,7 @@ describe("Composable cache handler", () => {
 			);
 
 			// Mock the get response
-			incrementalCache.get.mockResolvedValueOnce({
+			cache.get.mockResolvedValueOnce({
 				value: {
 					...entry,
 					value: "integration-test",
@@ -518,8 +283,8 @@ describe("Composable cache handler", () => {
 
 			const results = await Promise.all(promises);
 
-			expect(incrementalCache.set).toHaveBeenCalledTimes(2);
-			expect(incrementalCache.get).not.toHaveBeenCalled();
+			expect(cache.set).toHaveBeenCalledTimes(2);
+			expect(cache.get).not.toHaveBeenCalled();
 
 			expect(results[2]).toBeDefined();
 			expect(results[3]).toBeDefined();

--- a/packages/tests-unit/tests/core/routing/cacheInterceptor.test.ts
+++ b/packages/tests-unit/tests/core/routing/cacheInterceptor.test.ts
@@ -46,19 +46,12 @@ function createEvent(event: PartialEvent): MiddlewareEvent {
 	};
 }
 
-const incrementalCache = {
+const cache = {
 	name: "mock",
 	get: vi.fn(),
 	set: vi.fn(),
 	delete: vi.fn(),
-};
-
-const tagCache = {
-	name: "mock",
-	getByTag: vi.fn(),
-	getByPath: vi.fn(),
-	getLastModified: vi.fn(),
-	writeTags: vi.fn(),
+	revalidateTags: vi.fn(),
 };
 
 const queue = {
@@ -68,12 +61,10 @@ const queue = {
 
 declare global {
 	var queue: Queue;
-	var incrementalCache: any;
-	var tagCache: any;
+	var cache: any;
 }
 
-globalThis.incrementalCache = incrementalCache;
-globalThis.tagCache = tagCache;
+globalThis.cache = cache;
 globalThis.queue = queue;
 
 beforeEach(() => {
@@ -110,12 +101,12 @@ describe("cacheInterceptor", () => {
 		expect(result).toEqual(event);
 	});
 
-	it("should take no action when incremental cache throws", async () => {
+	it("should take no action when cache throws", async () => {
 		const event = createEvent({
 			url: "/albums",
 		});
 
-		incrementalCache.get.mockRejectedValueOnce(new Error("mock error"));
+		cache.get.mockRejectedValueOnce(new Error("mock error"));
 		const result = await cacheInterceptor(event);
 
 		expect(result).toEqual(event);
@@ -125,7 +116,7 @@ describe("cacheInterceptor", () => {
 		const event = createEvent({
 			url: "/albums",
 		});
-		incrementalCache.get.mockResolvedValueOnce({
+		cache.get.mockResolvedValueOnce({
 			value: {
 				type: "app",
 				html: "Hello, world!",
@@ -151,64 +142,11 @@ describe("cacheInterceptor", () => {
 		);
 	});
 
-	it("should take no action when tagCache lasModified is -1 for app type", async () => {
-		const event = createEvent({
-			url: "/albums",
-		});
-		incrementalCache.get.mockResolvedValueOnce({
-			value: {
-				type: "app",
-				html: "Hello, world!",
-			},
-		});
-		tagCache.getLastModified.mockResolvedValueOnce(-1);
-
-		const result = await cacheInterceptor(event);
-
-		expect(result).toEqual(event);
-	});
-
-	it("should bypass the tag cache when shouldBypassTagCache is true", async () => {
-		const event = createEvent({
-			url: "/albums",
-		});
-		incrementalCache.get.mockResolvedValueOnce({
-			value: {
-				type: "app",
-				html: "Hello, world!",
-			},
-			shouldBypassTagCache: true,
-		});
-
-		await cacheInterceptor(event);
-
-		expect(tagCache.getLastModified).not.toHaveBeenCalled();
-	});
-
-	it("should take no action when tagCache lasModified is -1 for route type", async () => {
-		const event = createEvent({
-			url: "/albums",
-		});
-
-		const body = "route";
-		incrementalCache.get.mockResolvedValueOnce({
-			value: {
-				type: "route",
-				body: body,
-				revalidate: false,
-			},
-			lastModified: new Date("2024-01-01T23:58:00Z").getTime(),
-		});
-		tagCache.getLastModified.mockResolvedValueOnce(-1);
-		const result = await cacheInterceptor(event);
-		expect(result).toEqual(event);
-	});
-
 	it("should retrieve page router content from stale cache", async () => {
 		const event = createEvent({
 			url: "/revalidate",
 		});
-		incrementalCache.get.mockResolvedValueOnce({
+		cache.get.mockResolvedValueOnce({
 			value: {
 				type: "page",
 				html: "Hello, world!",
@@ -240,7 +178,7 @@ describe("cacheInterceptor", () => {
 		const event = createEvent({
 			url: "/revalidate",
 		});
-		incrementalCache.get.mockResolvedValueOnce({
+		cache.get.mockResolvedValueOnce({
 			value: {
 				type: "page",
 				html: "Hello, world!",
@@ -272,7 +210,7 @@ describe("cacheInterceptor", () => {
 		const event = createEvent({
 			url: "/albums",
 		});
-		incrementalCache.get.mockResolvedValueOnce({
+		cache.get.mockResolvedValueOnce({
 			value: {
 				type: "redirect",
 				meta: {
@@ -301,7 +239,7 @@ describe("cacheInterceptor", () => {
 		const event = createEvent({
 			url: "/albums",
 		});
-		incrementalCache.get.mockResolvedValueOnce({
+		cache.get.mockResolvedValueOnce({
 			value: {
 				type: "?",
 				html: "Hello, world!",
@@ -318,7 +256,7 @@ describe("cacheInterceptor", () => {
 			url: "/albums",
 		});
 		const routeBody = JSON.stringify({ message: "Hello from API" });
-		incrementalCache.get.mockResolvedValueOnce({
+		cache.get.mockResolvedValueOnce({
 			value: {
 				type: "route",
 				body: routeBody,
@@ -358,7 +296,7 @@ describe("cacheInterceptor", () => {
 			url: "/albums",
 		});
 		const routeBody = "randomBinaryData";
-		incrementalCache.get.mockResolvedValueOnce({
+		cache.get.mockResolvedValueOnce({
 			value: {
 				type: "route",
 				body: routeBody,
@@ -398,7 +336,7 @@ describe("cacheInterceptor", () => {
 			url: "/albums",
 		});
 		const routeBody = "API response";
-		incrementalCache.get.mockResolvedValueOnce({
+		cache.get.mockResolvedValueOnce({
 			value: {
 				type: "route",
 				body: routeBody,
@@ -440,7 +378,7 @@ describe("cacheInterceptor", () => {
 			url: "/albums",
 		});
 		const routeBody = "Simple response";
-		incrementalCache.get.mockResolvedValueOnce({
+		cache.get.mockResolvedValueOnce({
 			value: {
 				type: "route",
 				body: routeBody,
@@ -473,7 +411,7 @@ describe("cacheInterceptor", () => {
 			url: "/albums",
 			rewriteStatusCode: 403,
 		});
-		incrementalCache.get.mockResolvedValueOnce({
+		cache.get.mockResolvedValueOnce({
 			value: {
 				type: "app",
 				html: "Hello, world!",
@@ -489,7 +427,7 @@ describe("cacheInterceptor", () => {
 			url: "/albums",
 			rewriteStatusCode: 203,
 		});
-		incrementalCache.get.mockResolvedValueOnce({
+		cache.get.mockResolvedValueOnce({
 			value: {
 				type: "app",
 				html: "Hello, world!",
@@ -507,7 +445,7 @@ describe("cacheInterceptor", () => {
 		const event = createEvent({
 			url: "/albums",
 		});
-		incrementalCache.get.mockResolvedValueOnce({
+		cache.get.mockResolvedValueOnce({
 			value: {
 				type: "app",
 				html: "Hello, world!",
@@ -525,7 +463,7 @@ describe("cacheInterceptor", () => {
 		const event = createEvent({
 			url: "/albums",
 		});
-		incrementalCache.get.mockResolvedValueOnce({
+		cache.get.mockResolvedValueOnce({
 			value: {
 				type: "app",
 				html: "Hello, world!",


### PR DESCRIPTION
> Part 3 of 6 of the cache stack, split out of #31. Review only this PR's diff — it is based on the previous branch.
>
> | | PR | Base |
> |---|---|---|
> | | #43 — core: dedicated cache handler function | `conico/share-build` (#35) |
> | | #44 — cloudflare: OpenNextCache entrypoint | #43 |
> | 👉 | **#45 — core: route all caching through the cache override ⚠️ breaking** | #44 |
> | | #46 — port SWR tag revalidation from AWS | #45 |
> | | #47 — core: honour Cache-Control on cache entries | #46 |
> | | #48 — cloudflare: per-entrypoint Workers caching | #47 |

**This is the breaking change of the stack**, and the only PR that changes runtime wiring for both adapters.

- Removes `incrementalCache` and `tagCache` from `OverrideOptions`; they are only configured under `cacheHandler`. `resolveIncrementalCache` and `resolveTagCache` follow. The esbuild resolve plugin keeps its own fields, so adapter `defaultOverrides` are unaffected.
- Moves tag revalidation — `hasBeenRevalidated`, `writeTags`, CDN invalidation — out of `adapters/cache.ts`, `composable-cache.ts` and `cacheInterceptor.ts` into the cache handler, which now applies them transparently in `get`, `set` and `revalidateTags`.
- `Cache.get` takes the additional tags to check, so the caller no longer needs the tag cache to resolve them.
- `defineCloudflareConfig` wires `cache` to the `OpenNextCache` entrypoint from PR 2 and moves the incremental cache, tag cache and cdn invalidation to `cacheHandler`. `ensureCloudflareConfig`, `populateCache` and `isPurgeCacheEnabled` read the new location.
- Examples move to `cache: "local"` with a `cacheHandler` block.

Roughly 400 lines of source; the rest is the corresponding rewrite of `cache.test.ts`, `composable-cache.test.ts` and `cacheInterceptor.test.ts`, plus the new `cache-adapter.test.ts`.

Migration for configurations not created by `defineCloudflareConfig`:

```diff
  default: {
    override: {
-     incrementalCache: "s3",
-     tagCache: "dynamodb",
+     cache: "local",
    },
  },
+ cacheHandler: {
+   incrementalCache: "s3",
+   tagCache: "dynamodb",
+ },
```